### PR TITLE
change junit scope to test to avoid exporting it on the runtime classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.5</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
A simple change to restrict junit to the test scope
