### PR TITLE
Avoid untrusted https certificate by switching to http for repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	
-<!--	<parent>
+	<parent>
 		<artifactId>config-java6</artifactId>
 		<groupId>dfki.km.maven</groupId>
 		<version>0.3.2</version>
-	</parent> -->
+	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dfki.km.json</groupId>
 	<artifactId>jsonld-java</artifactId>
@@ -40,10 +40,10 @@
 		</dependency>
 	</dependencies>
 	
-<!--	<repositories>
+	<repositories>
 		<repository>
 			<id>artifactory2-libs-releases</id>
-            <url>https://www.dfki.uni-kl.de/artifactory2/libs-releases</url>
+            <url>http://www.dfki.uni-kl.de/artifactory2/libs-releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -51,7 +51,7 @@
                 <enabled>false</enabled>
             </snapshots>
 		</repository>
-	</repositories> -->
+	</repositories>
 	
 </project>
 


### PR DESCRIPTION
The HTTPS certificate for https://www.dfki.uni-kl.de is not trusted by my browser, or by java on my computer, so I switched to using http://www.dfki.uni-kl.de which works just as well, although not secure.
