### PR TITLE
comment out unreachable catch blocks so compile works

### DIFF
--- a/src/main/java/de/dfki/km/json/jsonld/JSONLDSerializer.java
+++ b/src/main/java/de/dfki/km/json/jsonld/JSONLDSerializer.java
@@ -189,13 +189,13 @@ public class JSONLDSerializer {
 	public String asString() {
 		// TODO: catching the exceptions here and returning JSON with the error messages may not
 		// be the best idea
-		try {
+//		try {
 			return JSONUtils.toString(asObject());
-		} catch (JsonGenerationException e) {
-			return "{\"error\":\"" + e.getLocalizedMessage() + "\"}";
-		} catch (JsonMappingException e) {
-			return "{\"error\":\"" + e.getLocalizedMessage() + "\"}";
-		}
+//		} catch (JsonGenerationException e) {
+//			return "{\"error\":\"" + e.getLocalizedMessage() + "\"}";
+//		} catch (JsonMappingException e) {
+//			return "{\"error\":\"" + e.getLocalizedMessage() + "\"}";
+//		}
 	}
 	
 }

--- a/src/main/java/de/dfki/km/json/jsonld/RDF2JSONLD.java
+++ b/src/main/java/de/dfki/km/json/jsonld/RDF2JSONLD.java
@@ -62,17 +62,17 @@ public class RDF2JSONLD {
 			}
 			
 			if (output != null) {
-				try {
+//				try {
 					System.out.println(JSONUtils.toString(output));
-				} catch (JsonGenerationException e) {
-					System.out.println("Error: unable to create JSON output from input");
-					e.printStackTrace();
-					usage();
-				} catch (JsonMappingException e) {
-					System.out.println("Error: unable to create JSON output from input");
-					e.printStackTrace();
-					usage();
-				}
+//				} catch (JsonGenerationException e) {
+//					System.out.println("Error: unable to create JSON output from input");
+//					e.printStackTrace();
+//					usage();
+//				} catch (JsonMappingException e) {
+//					System.out.println("Error: unable to create JSON output from input");
+//					e.printStackTrace();
+//					usage();
+//				}
 			}
 		}
 	}


### PR DESCRIPTION
The build broke for me when compiling as JSONUtils.toString no longer throws exceptions.

The blocks are only commented out as I am not sure if JSONUtils will be changed back to throw exceptions.
