### PR TITLE
avoid null pointer exception in sesame serialiser

### DIFF
--- a/src/main/java/de/dfki/km/json/jsonld/impl/SesameJSONLDSerializer.java
+++ b/src/main/java/de/dfki/km/json/jsonld/impl/SesameJSONLDSerializer.java
@@ -31,8 +31,16 @@ public class SesameJSONLDSerializer extends de.dfki.km.json.jsonld.JSONLDSeriali
             String value = literal.getLabel();
             URI datatypeURI = literal.getDatatype();
             String language = literal.getLanguage();
-
-            triple(subject.stringValue(), predicate.stringValue(), value, datatypeURI.stringValue(), language);
+            
+            String datatype;
+            
+            if (datatypeURI == null) {
+                datatype = null;
+            } else {
+                datatype = datatypeURI.stringValue();
+            }
+            
+            triple(subject.stringValue(), predicate.stringValue(), value, datatype, language);
         } else {
             triple(subject.stringValue(), predicate.stringValue(), object.stringValue());
         }


### PR DESCRIPTION
Datatype can be legitimately null, so avoid trying to convert it to a string in these cases, and just pass through null
