### PR TITLE
bump sesame version to 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.openrdf.sesame</groupId>
 			<artifactId>sesame-model</artifactId>
-			<version>2.6.3</version>
+			<version>2.6.4</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>


### PR DESCRIPTION
Recent sesame release, 2.6.4, contains fixes for bugs I encountered in other projects. I am not sure how many of them relate to sesame-model that is used here, but easier for maven dependency trees downstream to upgrade.
