### PR TITLE
Adding support of toPrettyString in JSONLDSerializer asString w/ new flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.8.5</version>
+			<version>1.9.4</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/src/main/java/de/dfki/km/json/JSONUtils.java
+++ b/src/main/java/de/dfki/km/json/JSONUtils.java
@@ -16,6 +16,7 @@ import org.codehaus.jackson.JsonLocation;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.ObjectWriter;
 
 /**
  * A bunch of functions to make loading JSON easy
@@ -117,6 +118,13 @@ public class JSONUtils {
         objectMapper.writeValue(w, jsonObject);
     }
 
+    public static void writePrettyPrint(Writer w, Object jsonObject) throws JsonGenerationException, JsonMappingException, IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
+        
+        objectWriter.writeValue(w, jsonObject);
+    }
+
     public static Object fromInputStream(InputStream content) throws IOException {
         return fromInputStream(content, "UTF-8"); // no readers from
                                                   // inputstreams w.o.
@@ -128,14 +136,16 @@ public class JSONUtils {
     }
 
     public static String toPrettyString(Object obj) {
-        ObjectMapper mapper = new ObjectMapper();
-
+        StringWriter sw = new StringWriter();
         try {
-            return mapper.defaultPrettyPrintingWriter().writeValueAsString(obj);
+            writePrettyPrint(sw, obj);
         } catch (Exception e) {
-            // TODO: if the obj isn't valid json this should throw an exception of some kind
-            return "";
+            // TODO Is this really possible with stringwriter?
+            // I think it's only there because of the interface
+            // however, if so... well, we have to do something!
+            // it seems weird for toString to throw an IOException
         }
+        return sw.toString();
     }
 
     public static String toString(Object obj) { // throws

--- a/src/main/java/de/dfki/km/json/jsonld/JSONLDSerializer.java
+++ b/src/main/java/de/dfki/km/json/jsonld/JSONLDSerializer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.io.Writer;
 
 import de.dfki.km.json.JSONUtils;
 
@@ -199,6 +200,15 @@ public class JSONLDSerializer {
             return rval;
         } else {
             return subjects;
+        }
+    }
+
+    public void toWriter(Writer writer) {
+        try {
+            JSONUtils.writePrettyPrint(writer, asObject());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
New asString method with flag to enable String output with PrettyPrint format. Added a new method just so we don't break existing usage of the previous asString() method.
In future releases asString() method without flag could be deprecated or be the default behavior.
