### PR TITLE
Recursively expands shortened URIs

### DIFF
--- a/src/main/java/de/dfki/km/json/jsonld/JSONLDUtils.java
+++ b/src/main/java/de/dfki/km/json/jsonld/JSONLDUtils.java
@@ -243,7 +243,12 @@ public class JSONLDUtils {
 
         }
 
-        return rval;
+        if (!term.equals(rval)) {
+        	//recurse
+        	return expandTerm(ctx, rval, usedCtx);
+        } else {
+        	return rval;
+        }
     }
 
     public static boolean isReference(Object value) {

--- a/src/test/java/de/dfki/km/json/jsonld/ClerezzaTripleCallbackTest.java
+++ b/src/test/java/de/dfki/km/json/jsonld/ClerezzaTripleCallbackTest.java
@@ -2,6 +2,7 @@ package de.dfki.km.json.jsonld;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +31,25 @@ public class ClerezzaTripleCallbackTest {
 			System.out.println(t);
 		}
 		assertEquals("Graph size",13, graph.size());
+		
+	}
+	
+	@Test
+	public void curiesInContextTest() throws IOException {
+		InputStream in = getClass().getClassLoader().getResourceAsStream("testfiles/curies-in-context.jsonld");
+		Object input = JSONUtils.fromInputStream(in);
+		
+		JSONLDProcessor processor = new JSONLDProcessor();
+		ClerezzaTripleCallback callback = new ClerezzaTripleCallback();
+
+		processor.triples(input, callback);
+		MGraph graph = callback.getMGraph();
+
+		for (Triple t : graph) {
+			System.out.println(t);
+			assertTrue("Predicate got fully expanded", t.getPredicate().getUnicodeString().startsWith("http"));
+		}
+		assertEquals("Graph size",3, graph.size());
 		
 	}
 }

--- a/src/test/resources/testfiles/curies-in-context.jsonld
+++ b/src/test/resources/testfiles/curies-in-context.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "Person": "foaf:Person",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "name": "foaf:name"
+  },
+  "@type": "Person",
+  "name": "Santa Claus",
+  "foaf:nick": "Sämi"
+}


### PR DESCRIPTION
This should fix issue #23.  Rather than expanding the context itself (as the issue suggests) json-ld shortened URIs are now recursively expanded till no further expansion is possible. e.g. "name" might be expanded to "foaf:name" before recursion and to "http://xmlns.com/foaf/0.1/name" on the first recursion. As http is not a prefix the value cannot be further expanded and is thus returned.
