### PR TITLE
Add graph/context support to SesameJSONLDSerializer and SesameTripleCallback

### DIFF
--- a/src/main/java/de/dfki/km/json/jsonld/impl/SesameJSONLDSerializer.java
+++ b/src/main/java/de/dfki/km/json/jsonld/impl/SesameJSONLDSerializer.java
@@ -27,7 +27,8 @@ public class SesameJSONLDSerializer extends de.dfki.km.json.jsonld.JSONLDSeriali
         Resource subject = nextStatement.getSubject();
         URI predicate = nextStatement.getPredicate();
         Value object = nextStatement.getObject();
-
+        String graph = nextStatement.getContext() == null ? null : nextStatement.getContext().stringValue();
+        
         if (object instanceof Literal) {
             Literal literal = (Literal) object;
             String value = literal.getLabel();
@@ -42,9 +43,9 @@ public class SesameJSONLDSerializer extends de.dfki.km.json.jsonld.JSONLDSeriali
                 datatype = datatypeURI.stringValue();
             }
             
-            triple(subject.stringValue(), predicate.stringValue(), value, datatype, language);
+            triple(subject.stringValue(), predicate.stringValue(), value, datatype, language, graph);
         } else {
-            triple(subject.stringValue(), predicate.stringValue(), object.stringValue());
+            triple(subject.stringValue(), predicate.stringValue(), object.stringValue(), graph);
         }
     }
 

--- a/src/main/java/de/dfki/km/json/jsonld/impl/SesameTripleCallback.java
+++ b/src/main/java/de/dfki/km/json/jsonld/impl/SesameTripleCallback.java
@@ -32,8 +32,14 @@ public class SesameTripleCallback extends JSONLDTripleCallback {
 
         // This method is always called with three URIs as subject predicate and
         // object
-        Statement result = vf.createStatement(vf.createURI(s), vf.createURI(p), vf.createURI(o));
-        storageGraph.add(result);
+        if(graph == null) {
+            Statement result = vf.createStatement(vf.createURI(s), vf.createURI(p), vf.createURI(o));
+            storageGraph.add(result);
+        } else {
+            Statement result = vf.createStatement(vf.createURI(s), vf.createURI(p), vf.createURI(o), vf.createURI(graph));
+            storageGraph.add(result);
+        }
+        
     }
 
     @Override
@@ -57,8 +63,13 @@ public class SesameTripleCallback extends JSONLDTripleCallback {
             object = vf.createLiteral(value);
         }
 
-        Statement result = vf.createStatement(subject, predicate, object);
-        storageGraph.add(result);
+        if(graph == null) {
+            Statement result = vf.createStatement(subject, predicate, object);
+            storageGraph.add(result);
+        } else {
+            Statement result = vf.createStatement(subject, predicate, object, vf.createURI(graph));
+            storageGraph.add(result);
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for Sesame statements coming into and out of jsonld-java when there is a non-null graph attached to either the Sesame Statement or the JSONLD quad/triple.
