### PR TITLE
Remove <pluginManagement>, make mvn plugins global

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
 	</dependencyManagement>
 	
 	<build>
-		<pluginManagement>
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -158,7 +157,6 @@
 					<version>2.14.1</version>
 				</plugin>
 			</plugins>
-		</pluginManagement>
 	</build>
 </project>
 


### PR DESCRIPTION
ie. so that source JARs etc. are built for each submodule, even
if they don't include the appropriate <plugin>.
