### PR TITLE
Update class name

### DIFF
--- a/integration/sesame/src/main/resources/META-INF/services/org.openrdf.rio.RDFWriterFactory
+++ b/integration/sesame/src/main/resources/META-INF/services/org.openrdf.rio.RDFWriterFactory
@@ -1,1 +1,1 @@
-de.dfki.km.json.jsonld.impl.SesameJSONLDWriterFactory
+com.github.jsonldjava.impl.SesameJSONLDWriterFactory


### PR DESCRIPTION
There seem to be some old class names left over. They cause runtime errors like this:

``` none
java.util.ServiceConfigurationError: org.openrdf.rio.RDFParserFactory: Provider de.dfki.km.json.jsonld.impl.SesameJSONLDParserFactory not found
    at java.util.ServiceLoader.fail(ServiceLoader.java:231)
    at java.util.ServiceLoader.access$300(ServiceLoader.java:181)
    at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:365)
    at java.util.ServiceLoader$1.next(ServiceLoader.java:445)
    at info.aduna.lang.service.ServiceRegistry.<init>(ServiceRegistry.java:52)
    at info.aduna.lang.service.FileFormatServiceRegistry.<init>(FileFormatServiceRegistry.java:31)
    at org.openrdf.rio.RDFParserRegistry.<init>(RDFParserRegistry.java:44)
...
```
