### PR TITLE
fromReader() to avoid reading char by char, by using a 4k buffer

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/utils/JSONUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/utils/JSONUtils.java
@@ -129,9 +129,10 @@ public class JSONUtils {
 
     public static Object fromReader(Reader r) throws IOException {
         final StringBuffer sb = new StringBuffer();
+        char[] buffer = new char[4096];
         int b;
-        while ((b = r.read()) != -1) {
-            sb.append((char) b);
+        while ((b = r.read(buffer)) != -1) {
+            sb.append(buffer, 0, b);
         }
         return fromString(sb.toString());
     }
@@ -159,7 +160,7 @@ public class JSONUtils {
     }
 
     public static Object fromInputStream(InputStream content, String enc) throws IOException {
-        return fromReader(new BufferedReader(new InputStreamReader(content, enc)));
+        return fromReader(new InputStreamReader(content, enc));
     }
 
     public static String toPrettyString(Object obj) {


### PR DESCRIPTION
This also removes the need for BufferedReader.

IOUtils.toString() would normally do this, in effect just like in my patch - but I did not want to add another dependency just for that.
