### PR TITLE
Update dependency to Jena 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		
 		<clerezza.version>0.13</clerezza.version>
 		<jackson.version>2.2.3</jackson.version>
-		<jena.version>2.10.0</jena.version>
+		<jena.version>2.11.0</jena.version>
 		<junit.version>4.11</junit.version>
 		<rdf2go.version>4.7.4</rdf2go.version>
 		<sesame.version>2.7.6</sesame.version>


### PR DESCRIPTION
Update Jena dependency to use recently released 0.11.0 which is settling some of the RIOT APIs from 0.10.0 vs 0.10.1.

Could we do a release of 0.3.0 as well? (Semantic versioning ++).  I need this to release a different project.
