### PR TITLE
Windows 8 compatibility: Split by \n instead of line.separator

### DIFF
--- a/integration/jena/src/test/java/com/github/jsonldjava/impl/JenaTripleCallbackTest.java
+++ b/integration/jena/src/test/java/com/github/jsonldjava/impl/JenaTripleCallbackTest.java
@@ -72,9 +72,10 @@ public class JenaTripleCallbackTest {
         model.write(w, "N-TRIPLE");
 
         final List<String> result = new ArrayList<String>(Arrays.asList(w.getBuffer().toString()
-                .split(System.getProperty("line.separator"))));
+                .split("\n")));
         Collections.sort(result);
-
+//        System.out.println(expected);
+//        System.out.println(result);
         assertTrue(Obj.equals(expected, result));
     }
 


### PR DESCRIPTION
test failed on Windows 8 with Java 7. Split on \n instead of line.separator.
