### PR TITLE
enable support for remote contexts

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/DocumentLoader.java
+++ b/core/src/main/java/com/github/jsonldjava/core/DocumentLoader.java
@@ -1,11 +1,10 @@
 package com.github.jsonldjava.core;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.github.jsonldjava.utils.JSONUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -17,23 +16,22 @@ import org.apache.http.impl.client.SystemDefaultHttpClient;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClient;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.MappingJsonFactory;
-import com.github.jsonldjava.utils.JSONUtils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 
 public class DocumentLoader {
 
     public RemoteDocument loadDocument(String url) throws JsonLdError {
-        // TODO: use fromURL to load document
-        // TODO: get http link context
-        return new RemoteDocument("", null);
-        /*
-         * } catch (Exception e) { // If context cannot be dereferenced throw
-         * new JsonLdError(Error.LOADING_REMOTE_CONTEXT_FAILED,
-         * (String)context); }
-         */
+        RemoteDocument doc = new RemoteDocument(url, null);
+        try {
+            doc.setDocument(fromURL(new URL(url)));
+        } catch (Exception e) {
+          new JsonLdError(JsonLdError.Error.LOADING_REMOTE_CONTEXT_FAILED, url);
+        }
+        return doc;
     }
 
     /**

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
@@ -125,5 +125,5 @@ public class JsonLdOptions {
     public String format = null;
     public Boolean useNamespaces = false;
     public String outputForm = null;
-    public DocumentLoader documentLoader;
+    public DocumentLoader documentLoader = new DocumentLoader();
 }


### PR DESCRIPTION
All code to support remote contexts seems to be there, but was not made available. I rewrote DocumentLoader.loadDocument to use functionality available and added a DocumentLoader instance to the default jsonld options.
