### PR TITLE
Fix for issue #144.

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
@@ -103,7 +103,7 @@ public class JsonUtils {
      */
     public static Object fromReader(Reader reader) throws IOException {
         final JsonParser jp = JSON_FACTORY.createParser(reader);
-        Object rval = null;
+        Object rval ;
         final JsonToken initialToken = jp.nextToken();
 
         if (initialToken == JsonToken.START_ARRAY) {
@@ -123,6 +123,16 @@ public class JsonUtils {
             throw new JsonParseException("document doesn't start with a valid json element : "
                     + initialToken, jp.getCurrentLocation());
         }
+        
+        JsonToken t ;
+        try { t = jp.nextToken(); }
+        catch (JsonParseException ex) {
+            throw new JsonParseException("Document contains more content after json-ld element - (possible mismatched {}?)",
+                                         jp.getCurrentLocation());
+        }
+        if ( t != null )
+            throw new JsonParseException("Document contains possible json content after the json-ld element - (possible mismatched {}?)",
+                                             jp.getCurrentLocation());
         return rval;
     }
 

--- a/core/src/test/java/com/github/jsonldjava/utils/JsonUtilsTest.java
+++ b/core/src/test/java/com/github/jsonldjava/utils/JsonUtilsTest.java
@@ -2,7 +2,10 @@ package com.github.jsonldjava.utils;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException ;
 import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParseException ;
 
 import org.junit.Test;
 
@@ -30,5 +33,33 @@ public class JsonUtilsTest {
         } catch (final Exception e) {
             assertTrue(true);
         }
+    }
+    
+    @Test
+    public void trailingContent_1() throws JsonParseException, IOException { trailingContent("{}") ; }
+
+    @Test
+    public void trailingContent_2() throws JsonParseException, IOException { trailingContent("{}  \t  \r \n  \r\n   ") ; }
+
+    @Test(expected=JsonParseException.class)
+    public void trailingContent_3() throws JsonParseException, IOException { trailingContent("{}x") ; }
+
+    @Test(expected=JsonParseException.class)
+    public void trailingContent_4() throws JsonParseException, IOException { trailingContent("{}   x") ; }
+
+    @Test(expected=JsonParseException.class)
+    public void trailingContent_5() throws JsonParseException, IOException { trailingContent("{} \"x\"") ; }
+
+    @Test(expected=JsonParseException.class)
+    public void trailingContent_6() throws JsonParseException, IOException { trailingContent("{} {}") ; }
+
+    @Test(expected=JsonParseException.class)
+    public void trailingContent_7() throws JsonParseException, IOException { trailingContent("{},{}") ; }
+
+    @Test(expected=JsonParseException.class)
+    public void trailingContent_8() throws JsonParseException, IOException { trailingContent("{},[]") ; }
+
+    private void trailingContent(String string) throws JsonParseException, IOException {
+            JsonUtils.fromString(string) ;
     }
 }

--- a/integration/sesame/src/test/java/com/github/jsonldjava/sesame/SesameLocaleNumericTest.java
+++ b/integration/sesame/src/test/java/com/github/jsonldjava/sesame/SesameLocaleNumericTest.java
@@ -70,6 +70,6 @@ public class SesameLocaleNumericTest {
 
     private String getTestString() {
         return "{" + "\"@id\": \"http://www.ex.com/product\"," + "\"http://schema.org/price\": {"
-                + "\"@value\": 100.00" + "}}}";
+                + "\"@value\": 100.00" + "}}";
     }
 }


### PR DESCRIPTION
This is a potential fix for issue #144.

A decision to be made is whether this invalidation of existing (but wrong) data is what the community wants.  (See, for example, the fix to the sesame integration testing which illustrates this)

One consideration for this fix is that no RDF is generated because of trailing content.  It would be better if RDF was generated then a parse error thrown. This does not seem is not possible without changing the way parsing happens, and the API, because the JsonParser goes out of scope at the end of JSON parsing, before production of RDF.
