### PR TITLE
Migrate DocumentLoader static implementations to JSONUtils

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
@@ -173,7 +173,9 @@ public class JsonUtils {
      *             If there was a JSON related error during parsing.
      * @throws IOException
      *             If there was an IO error during parsing.
+     * @deprecated Use {@link #fromURL(java.net.URL, CloseableHttpClient)} instead.
      */
+    @Deprecated
     public static Object fromURL(java.net.URL url) throws JsonParseException, IOException {
         return fromURL(url, getDefaultHttpClient());
     }
@@ -279,6 +281,21 @@ public class JsonUtils {
         }
     }
 
+    /**
+     * Parses a JSON-LD document, from the contents of the JSON resource
+     * resolved from the JsonLdUrl, to an object that can be used as input for
+     * the {@link JsonLdApi} and {@link JsonLdProcessor} methods.
+     *
+     * @param url
+     *            The JsonLdUrl to resolve
+     * @param httpClient 
+     *            The {@link CloseableHttpClient} to use to resolve the URL.
+     * @return A JSON Object.
+     * @throws JsonParseException
+     *             If there was a JSON related error during parsing.
+     * @throws IOException
+     *             If there was an IO error during parsing.
+     */
     public static Object fromURL(java.net.URL url, CloseableHttpClient httpClient) throws JsonParseException, IOException {
         final InputStream in = openStreamForURL(url, httpClient);
         try {

--- a/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
@@ -254,6 +254,15 @@ public class JsonUtils {
         jw.writeObject(jsonObject);
     }
 
+    /**
+     * Attempts to open an {@link InputStream} that will contain the content of the URL, as resolved by the given HTTP Client.
+     * 
+     * If the URL is not an HTTP or HTTPS URL it is resolved using the default {@link java.net.URL#openStream()} method.
+     * @param url The URL to resolve.
+     * @param httpClient The CloseableHttpClient to use to resolve the URL.
+     * @return An InputStream containing the contents of the resolved URL.
+     * @throws IOException If there are any IO exceptions while resolving the URL.
+     */
     public static InputStream openStreamForURL(java.net.URL url, CloseableHttpClient httpClient) throws IOException {
         final String protocol = url.getProtocol();
         if (!protocol.equalsIgnoreCase("http") && !protocol.equalsIgnoreCase("https")) {

--- a/core/src/test/java/com/github/jsonldjava/core/ArrayContextToRDFTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ArrayContextToRDFTest.java
@@ -16,12 +16,12 @@ public class ArrayContextToRDFTest {
 
         final URL contextUrl = getClass().getResource("/custom/contexttest-0001.jsonld");
         assertNotNull(contextUrl);
-        final Object context = JsonUtils.fromURL(contextUrl);
+        final Object context = JsonUtils.fromURL(contextUrl, JsonUtils.getDefaultHttpClient());
         assertNotNull(context);
 
         final URL arrayContextUrl = getClass().getResource("/custom/array-context.jsonld");
         assertNotNull(arrayContextUrl);
-        final Object arrayContext = JsonUtils.fromURL(arrayContextUrl);
+        final Object arrayContext = JsonUtils.fromURL(arrayContextUrl, JsonUtils.getDefaultHttpClient());
         assertNotNull(arrayContext);
         final JsonLdOptions options = new JsonLdOptions();
         options.useNamespaces = true;

--- a/core/src/test/java/com/github/jsonldjava/core/LongestPrefixTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/LongestPrefixTest.java
@@ -17,7 +17,7 @@ public class LongestPrefixTest {
 
         final URL contextUrl = getClass().getResource("/custom/contexttest-0003.jsonld");
         assertNotNull(contextUrl);
-        final Object context = JsonUtils.fromURL(contextUrl);
+        final Object context = JsonUtils.fromURL(contextUrl, JsonUtils.getDefaultHttpClient());
         assertNotNull(context);
 
         final JsonLdOptions options = new JsonLdOptions();


### PR DESCRIPTION
There are many DocumentLoader implementations that would fit better as static methods in JSONUtils for maintenance purposes. The DocumentLoader methods have been deprecated for future removal