### PR TITLE
Notes, code and request for comments regarding Issue 172

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -1797,6 +1797,24 @@ public class JsonLdApi {
      *             If there was an error during conversion from RDF to JSON-LD.
      */
     public List<Object> fromRDF(final RDFDataset dataset) throws JsonLdError {
+    	// by default, don't change anything to current way of doing things
+    	return fromRDF(dataset, false);
+    }
+    
+    /**
+     * Converts RDF statements into JSON-LD.
+     *
+     * @param dataset
+     *            the RDF statements.
+     * @param noDupsInDataset
+     *            if you know that dataset doesn't contain duplicated triples, and only in this case,
+     *            pass true in noDupsInDataset to improve the performance of this call.
+     *            
+     * @return A list of JSON-LD objects found in the given dataset.
+     * @throws JsonLdError
+     *             If there was an error during conversion from RDF to JSON-LD.
+     */
+    public List<Object> fromRDF(final RDFDataset dataset, boolean noDupsInDataset) throws JsonLdError {
         // 1)
         final Map<String, NodeMapNode> defaultGraph = new LinkedHashMap<String, NodeMapNode>();
         // 2)
@@ -1854,7 +1872,11 @@ public class JsonLdApi {
                 final Map<String, Object> value = object.toObject(opts.getUseNativeTypes());
 
                 // 3.5.6+7)
-                JsonLdUtils.mergeValue(node, predicate, value);
+                if (noDupsInDataset) {
+                	JsonLdUtils.mergeValue_lax(node, predicate, value);
+                } else {
+                	JsonLdUtils.mergeValue(node, predicate, value);
+                }
 
                 // 3.5.8)
                 if (object.isBlankNode() || object.isIRI()) {

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
@@ -118,6 +118,18 @@ public class JsonLdUtils {
         }
     }
 
+    static void mergeValue_lax(Map<String, Object> obj, String key, Object value) {
+      if (obj == null) {
+          return;
+      }
+      List<Object> values = (List<Object>) obj.get(key);
+      if (values == null) {
+          values = new ArrayList<Object>();
+          obj.put(key, values);
+      }
+      values.add(value);
+    }
+
     static void mergeCompactedValue(Map<String, Object> obj, String key, Object value) {
         if (obj == null) {
             return;

--- a/core/src/test/java/com/github/jsonldjava/core/Issue172Test.java
+++ b/core/src/test/java/com/github/jsonldjava/core/Issue172Test.java
@@ -1,0 +1,85 @@
+/* Created on 7 mai 2016 */
+package com.github.jsonldjava.core;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.github.jsonldjava.core.RDFDataset.Quad;
+import com.github.jsonldjava.utils.JsonUtils;
+
+public class Issue172Test {
+
+/** many triples with same subject and prop: current implementation is slow */
+@Test public final void slowVsFast() throws JsonLdError, JsonGenerationException, IOException {
+  RDFDataset inputRdf = new RDFDataset();
+  String ns = "http://www.example.com/foo/";
+  inputRdf.setNamespace("ex", ns);
+  
+  int n = 2000;
+  for (int i = 0 ; i < n ; i++) {
+    inputRdf.addTriple(ns + "s", ns + "o", ns + "p" + Integer.toString(i));  	
+  }
+  
+  final JsonLdOptions options = new JsonLdOptions();
+  options.useNamespaces = true;
+
+	
+	// warming
+	for (int i = 0 ; i < 2 ; i++) {
+	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+	}
+
+	for (int i = 0 ; i < 2 ; i++) {
+	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+	}
+
+	int nb = 10;
+	long start = System.currentTimeMillis();
+	for (int i = 0 ; i < nb ; i++) {
+	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+	}
+	System.out.println("Time to expand a dataset containing one subject with " + n + "different values of one prop:");
+	System.out.println("\t- JSON-LD java as it is: " + (((System.currentTimeMillis() - start)) / nb));
+
+	start = System.currentTimeMillis();
+	for (int i = 0 ; i < nb ; i++) {
+	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf, true));
+	}
+	System.out.println("\t- As it could be (?): " + (((System.currentTimeMillis() - start)) / nb));
+}
+
+@Test public final void duplicatedTriplesInAnRDFDataset() throws JsonLdError, JsonGenerationException, IOException {
+  RDFDataset inputRdf = new RDFDataset();
+  String ns = "http://www.example.com/foo/";
+  inputRdf.setNamespace("ex", ns);
+  inputRdf.addTriple(ns + "s", ns + "p", ns + "o");
+  inputRdf.addTriple(ns + "s", ns + "p", ns + "o");
+  
+  System.out.println("Twice the same triple in RDFDataset:/n");
+  for (Quad quad : inputRdf.getQuads("@default")) {
+  	System.out.println(quad);
+  }
+
+  final JsonLdOptions options = new JsonLdOptions();
+  options.useNamespaces = true;
+
+  Object fromRDF;
+  String jsonld;
+  
+  System.out.println("\nJSON-LD output is OK:\n");
+  fromRDF = JsonLdProcessor.compact(new JsonLdApi(options).fromRDF(inputRdf),
+          inputRdf.getContext(), options);
+
+  jsonld = JsonUtils.toPrettyString(fromRDF);
+  System.out.println(jsonld);
+  
+  System.out.println("\nWouldn't be the case assuming there is no duplicated triple in RDFDataset:\n");
+  fromRDF = JsonLdProcessor.compact(new JsonLdApi(options).fromRDF(inputRdf, true),
+      inputRdf.getContext(), options);
+  jsonld = JsonUtils.toPrettyString(fromRDF);
+  System.out.println(jsonld);
+
+}
+}

--- a/core/src/test/java/com/github/jsonldjava/core/Issue172Test.java
+++ b/core/src/test/java/com/github/jsonldjava/core/Issue172Test.java
@@ -11,75 +11,75 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 public class Issue172Test {
 
-/** many triples with same subject and prop: current implementation is slow */
-@Test public final void slowVsFast() throws JsonLdError, JsonGenerationException, IOException {
-  RDFDataset inputRdf = new RDFDataset();
-  String ns = "http://www.example.com/foo/";
-  inputRdf.setNamespace("ex", ns);
-  
-  int n = 2000;
-  for (int i = 0 ; i < n ; i++) {
-    inputRdf.addTriple(ns + "s", ns + "o", ns + "p" + Integer.toString(i));  	
-  }
-  
-  final JsonLdOptions options = new JsonLdOptions();
-  options.useNamespaces = true;
+	/** many triples with same subject and prop: current implementation is slow */
+	@Test public final void slowVsFast() throws JsonLdError, JsonGenerationException, IOException {
+		RDFDataset inputRdf = new RDFDataset();
+		String ns = "http://www.example.com/foo/";
+		inputRdf.setNamespace("ex", ns);
 
-	
-	// warming
-	for (int i = 0 ; i < 2 ; i++) {
-	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+		int n = 2000;
+		for (int i = 0 ; i < n ; i++) {
+			inputRdf.addTriple(ns + "s", ns + "o", ns + "p" + Integer.toString(i));  	
+		}
+
+		final JsonLdOptions options = new JsonLdOptions();
+		options.useNamespaces = true;
+
+
+		// warming
+		for (int i = 0 ; i < 2 ; i++) {
+			JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+		}
+
+		for (int i = 0 ; i < 2 ; i++) {
+			JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf, true));
+		}
+
+		int nb = 10;
+		long start = System.currentTimeMillis();
+		for (int i = 0 ; i < nb ; i++) {
+			JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+		}
+		System.out.println("Time to expand a dataset containing one subject with " + n + "different values of one prop:");
+		System.out.println("\t- JSON-LD java as it is: " + (((System.currentTimeMillis() - start)) / nb));
+
+		start = System.currentTimeMillis();
+		for (int i = 0 ; i < nb ; i++) {
+			JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf, true));
+		}
+		System.out.println("\t- As it could be (?): " + (((System.currentTimeMillis() - start)) / nb));
 	}
 
-	for (int i = 0 ; i < 2 ; i++) {
-	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
+	@Test public final void duplicatedTriplesInAnRDFDataset() throws JsonLdError, JsonGenerationException, IOException {
+		RDFDataset inputRdf = new RDFDataset();
+		String ns = "http://www.example.com/foo/";
+		inputRdf.setNamespace("ex", ns);
+		inputRdf.addTriple(ns + "s", ns + "p", ns + "o");
+		inputRdf.addTriple(ns + "s", ns + "p", ns + "o");
+
+		System.out.println("Twice the same triple in RDFDataset:/n");
+		for (Quad quad : inputRdf.getQuads("@default")) {
+			System.out.println(quad);
+		}
+
+		final JsonLdOptions options = new JsonLdOptions();
+		options.useNamespaces = true;
+
+		Object fromRDF;
+		String jsonld;
+
+		System.out.println("\nJSON-LD output is OK:\n");
+		fromRDF = JsonLdProcessor.compact(new JsonLdApi(options).fromRDF(inputRdf),
+				inputRdf.getContext(), options);
+
+		jsonld = JsonUtils.toPrettyString(fromRDF);
+		System.out.println(jsonld);
+
+		System.out.println("\nWouldn't be the case assuming there is no duplicated triple in RDFDataset:\n");
+		fromRDF = JsonLdProcessor.compact(new JsonLdApi(options).fromRDF(inputRdf, true),
+				inputRdf.getContext(), options);
+		jsonld = JsonUtils.toPrettyString(fromRDF);
+		System.out.println(jsonld);
+
 	}
-
-	int nb = 10;
-	long start = System.currentTimeMillis();
-	for (int i = 0 ; i < nb ; i++) {
-	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf));
-	}
-	System.out.println("Time to expand a dataset containing one subject with " + n + "different values of one prop:");
-	System.out.println("\t- JSON-LD java as it is: " + (((System.currentTimeMillis() - start)) / nb));
-
-	start = System.currentTimeMillis();
-	for (int i = 0 ; i < nb ; i++) {
-	  JsonLdProcessor.expand(new JsonLdApi(options).fromRDF(inputRdf, true));
-	}
-	System.out.println("\t- As it could be (?): " + (((System.currentTimeMillis() - start)) / nb));
-}
-
-@Test public final void duplicatedTriplesInAnRDFDataset() throws JsonLdError, JsonGenerationException, IOException {
-  RDFDataset inputRdf = new RDFDataset();
-  String ns = "http://www.example.com/foo/";
-  inputRdf.setNamespace("ex", ns);
-  inputRdf.addTriple(ns + "s", ns + "p", ns + "o");
-  inputRdf.addTriple(ns + "s", ns + "p", ns + "o");
-  
-  System.out.println("Twice the same triple in RDFDataset:/n");
-  for (Quad quad : inputRdf.getQuads("@default")) {
-  	System.out.println(quad);
-  }
-
-  final JsonLdOptions options = new JsonLdOptions();
-  options.useNamespaces = true;
-
-  Object fromRDF;
-  String jsonld;
-  
-  System.out.println("\nJSON-LD output is OK:\n");
-  fromRDF = JsonLdProcessor.compact(new JsonLdApi(options).fromRDF(inputRdf),
-          inputRdf.getContext(), options);
-
-  jsonld = JsonUtils.toPrettyString(fromRDF);
-  System.out.println(jsonld);
-  
-  System.out.println("\nWouldn't be the case assuming there is no duplicated triple in RDFDataset:\n");
-  fromRDF = JsonLdProcessor.compact(new JsonLdApi(options).fromRDF(inputRdf, true),
-      inputRdf.getContext(), options);
-  jsonld = JsonUtils.toPrettyString(fromRDF);
-  System.out.println(jsonld);
-
-}
 }


### PR DESCRIPTION
Hi,

this, as answer to the last comment by Peter Ansell about [issue 172](https://github.com/jsonld-java/jsonld-java/issues/172)

Summary:

- there is really a performance problem in the situation I mentioned
- it occurs where I said in the code
- the change that I suggested cannot be applied blindly
- but I think that in certain circonstances, the caller may know that he can use this optimisation: namely, when he knows that there are no duplicated triples in the RDFDataset
- here is included the possibility to optionally call it.

Peter you write:

> I can't seem to replicate your results locally, as removing the deepContains call doesn't seem to have any effect.

please have a look at ``com.github.jsonldjava.core.Issue172Test.slowVsFast()``. It shows that it may have a huge effect.

> I can't remove the entire if statement and just always add values as that breaks at least 19 of the conformance tests

I got another look at the code. I now think that we cannot make the change that I had suggested without any precaution (more on that later).

But I am surprised when you say that it breaks 19 tests, as I didn't see any one failing when running the tests included in the release. Note that if you run the tests with this version here, none fails but this is not an indication of anything, because as it is, only the unmodified code is called - my modification is only called when explicitly requested. If you want to run the tests with the modification being active (that is, if you want to replicate what I suppose that you have done when you got the 19 tests failing, change line 1801 in my modified JsonLdApi:


```
    public List<Object> fromRDF(final RDFDataset dataset) throws JsonLdError {
    	// by default, don't change anything to current way of doing things
    	return fromRDF(dataset, false);
    }
```

to:

```
    public List<Object> fromRDF(final RDFDataset dataset) throws JsonLdError {
    	// initial suggestion of fps
    	return fromRDF(dataset, true);
    }
```

and then run the tests. I don't see anyone failing. Do I miss something?

Anyway, the change that I suggested cannot be applied blindly. In a previous message, I said:

> But it is OK to use this "laxMergeValue" instead of mergeValue at line 1857 of JsonLdAPI? Well, I'll leave it to the persons who knows the code, but I think that it could be the case, as it seems to be about adding the triple

> node predicate value

> to the list of values of the property predicate of the node subject. 

This was wrong, because I was assuming that there are no duplicated triples in a RDFDataset. I was influenced by what we have in Jena, but this is not the case with JSONLD-java RDFDatasets, as I verified in 

`com.github.jsonldjava.core.Issue172Test.duplicatedTriplesInAnRDFDataset()`.

This test shows that an RDFDataSet may contain duplicated triples, and that the modification that I had suggested in not OK in such a case.

But I think that what I said is right if we know that RDFDataset doesn't contain duplicated triples: if we know that a given RDFDataset doesn't contain any duplicated triple, we may call a "lax" version of mergeValue in JsonLDApi.fromRDF, around line 1874:

```
                // 3.5.6+7)
                if (noDupsInDataset) {
                	JsonLdUtils.mergeValue_lax(node, predicate, value);
                } else {
                	JsonLdUtils.mergeValue(node, predicate, value);
                }
```

What do you, people who know and understand JSON-LD java code, think of this?

What I want to stress is that, in several important cases, a user of the API may know that the RDFDataset doesn't contain any duplicated triple. It is the case, for instance, when Jena passes a Jena model to JSON-LD java using ``JsonLdProcessor.fromRDF(Object input, RDFParser parser)``. It is guaranteed that there won't be any duplicated triples in the RDFDataset. So, he could benefit from calling a lax version of mergeValue in fromRDF. Hence the idea of 

``public List<Object> fromRDF(final RDFDataset dataset, boolean noDupsInDataset)``

Pass false (the default) and there's no modification in the behavior, pass true and the "lax mergeValue method" is called.

Note that there are probably other places in fromRDF where the lax mergeValue method could be called. To be seen.

Best,

fps
