### PR TITLE
Fix issue #175 using a hack for recursive context processing

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -55,7 +55,7 @@ public class Context extends LinkedHashMap<String, Object> {
     private void init(JsonLdOptions options) {
         this.options = options;
         if (options.getBase() != null) {
-            this.put("@base", options.getBase());
+            this.put(JsonLdConsts.BASE, options.getBase());
         }
         this.termDefinitions = newMap();
     }
@@ -75,7 +75,7 @@ public class Context extends LinkedHashMap<String, Object> {
         // 1)
         int numberMembers = value.size();
         // 2)
-        if (value.containsKey("@index") && "@index".equals(this.getContainer(activeProperty))) {
+        if (value.containsKey(JsonLdConsts.INDEX) && JsonLdConsts.INDEX.equals(this.getContainer(activeProperty))) {
             numberMembers--;
         }
         // 3)
@@ -85,36 +85,36 @@ public class Context extends LinkedHashMap<String, Object> {
         // 4)
         final String typeMapping = getTypeMapping(activeProperty);
         final String languageMapping = getLanguageMapping(activeProperty);
-        if (value.containsKey("@id")) {
+        if (value.containsKey(JsonLdConsts.ID)) {
             // 4.1)
-            if (numberMembers == 1 && "@id".equals(typeMapping)) {
-                return compactIri((String) value.get("@id"));
+            if (numberMembers == 1 && JsonLdConsts.ID.equals(typeMapping)) {
+                return compactIri((String) value.get(JsonLdConsts.ID));
             }
             // 4.2)
-            if (numberMembers == 1 && "@vocab".equals(typeMapping)) {
-                return compactIri((String) value.get("@id"), true);
+            if (numberMembers == 1 && JsonLdConsts.VOCAB.equals(typeMapping)) {
+                return compactIri((String) value.get(JsonLdConsts.ID), true);
             }
             // 4.3)
             return value;
         }
-        final Object valueValue = value.get("@value");
+        final Object valueValue = value.get(JsonLdConsts.VALUE);
         // 5)
-        if (value.containsKey("@type") && Obj.equals(value.get("@type"), typeMapping)) {
+        if (value.containsKey(JsonLdConsts.TYPE) && Obj.equals(value.get(JsonLdConsts.TYPE), typeMapping)) {
             return valueValue;
         }
         // 6)
-        if (value.containsKey("@language")) {
+        if (value.containsKey(JsonLdConsts.LANGUAGE)) {
             // TODO: SPEC: doesn't specify to check default language as well
-            if (Obj.equals(value.get("@language"), languageMapping)
-                    || Obj.equals(value.get("@language"), this.get("@language"))) {
+            if (Obj.equals(value.get(JsonLdConsts.LANGUAGE), languageMapping)
+                    || Obj.equals(value.get(JsonLdConsts.LANGUAGE), this.get(JsonLdConsts.LANGUAGE))) {
                 return valueValue;
             }
         }
         // 7)
         if (numberMembers == 1
-                && (!(valueValue instanceof String) || !this.containsKey("@language") || (termDefinitions
+                && (!(valueValue instanceof String) || !this.containsKey(JsonLdConsts.LANGUAGE) || (termDefinitions
                         .containsKey(activeProperty)
-                        && getTermDefinition(activeProperty).containsKey("@language") && languageMapping == null))) {
+                        && getTermDefinition(activeProperty).containsKey(JsonLdConsts.LANGUAGE) && languageMapping == null))) {
             return valueValue;
         }
         // 8)
@@ -157,7 +157,7 @@ public class Context extends LinkedHashMap<String, Object> {
             }
             // 3.2)
             else if (context instanceof String) {
-                String uri = (String) result.get("@base");
+                String uri = (String) result.get(JsonLdConsts.BASE);
                 uri = JsonLdUrl.resolve(uri, (String) context);
                 // 3.2.2
                 if (remoteContexts.contains(uri)) {
@@ -169,12 +169,12 @@ public class Context extends LinkedHashMap<String, Object> {
                 final RemoteDocument rd = this.options.getDocumentLoader().loadDocument(uri);
                 final Object remoteContext = rd.document;
                 if (!(remoteContext instanceof Map)
-                        || !((Map<String, Object>) remoteContext).containsKey("@context")) {
+                        || !((Map<String, Object>) remoteContext).containsKey(JsonLdConsts.CONTEXT)) {
                     // If the dereferenced document has no top-level JSON object
                     // with an @context member
                     throw new JsonLdError(Error.INVALID_REMOTE_CONTEXT, context);
                 }
-                context = ((Map<String, Object>) remoteContext).get("@context");
+                context = ((Map<String, Object>) remoteContext).get(JsonLdConsts.CONTEXT);
 
                 // 3.2.4
                 result = result.parse(context, remoteContexts);
@@ -186,19 +186,19 @@ public class Context extends LinkedHashMap<String, Object> {
             }
 
             // 3.4
-            if (remoteContexts.isEmpty() && ((Map<String, Object>) context).containsKey("@base")) {
-                final Object value = ((Map<String, Object>) context).get("@base");
+            if (remoteContexts.isEmpty() && ((Map<String, Object>) context).containsKey(JsonLdConsts.BASE)) {
+                final Object value = ((Map<String, Object>) context).get(JsonLdConsts.BASE);
                 if (value == null) {
-                    result.remove("@base");
+                    result.remove(JsonLdConsts.BASE);
                 } else if (value instanceof String) {
                     if (JsonLdUtils.isAbsoluteIri((String) value)) {
-                        result.put("@base", value);
+                        result.put(JsonLdConsts.BASE, value);
                     } else {
-                        final String baseUri = (String) result.get("@base");
+                        final String baseUri = (String) result.get(JsonLdConsts.BASE);
                         if (!JsonLdUtils.isAbsoluteIri(baseUri)) {
                             throw new JsonLdError(Error.INVALID_BASE_IRI, baseUri);
                         }
-                        result.put("@base", JsonLdUrl.resolve(baseUri, (String) value));
+                        result.put(JsonLdConsts.BASE, JsonLdUrl.resolve(baseUri, (String) value));
                     }
                 } else {
                     throw new JsonLdError(JsonLdError.Error.INVALID_BASE_IRI,
@@ -207,13 +207,13 @@ public class Context extends LinkedHashMap<String, Object> {
             }
 
             // 3.5
-            if (((Map<String, Object>) context).containsKey("@vocab")) {
-                final Object value = ((Map<String, Object>) context).get("@vocab");
+            if (((Map<String, Object>) context).containsKey(JsonLdConsts.VOCAB)) {
+                final Object value = ((Map<String, Object>) context).get(JsonLdConsts.VOCAB);
                 if (value == null) {
-                    result.remove("@vocab");
+                    result.remove(JsonLdConsts.VOCAB);
                 } else if (value instanceof String) {
                     if (JsonLdUtils.isAbsoluteIri((String) value)) {
-                        result.put("@vocab", value);
+                        result.put(JsonLdConsts.VOCAB, value);
                     } else {
                         throw new JsonLdError(Error.INVALID_VOCAB_MAPPING,
                                 "@value must be an absolute IRI");
@@ -225,12 +225,12 @@ public class Context extends LinkedHashMap<String, Object> {
             }
 
             // 3.6
-            if (((Map<String, Object>) context).containsKey("@language")) {
-                final Object value = ((Map<String, Object>) context).get("@language");
+            if (((Map<String, Object>) context).containsKey(JsonLdConsts.LANGUAGE)) {
+                final Object value = ((Map<String, Object>) context).get(JsonLdConsts.LANGUAGE);
                 if (value == null) {
-                    result.remove("@language");
+                    result.remove(JsonLdConsts.LANGUAGE);
                 } else if (value instanceof String) {
-                    result.put("@language", ((String) value).toLowerCase());
+                    result.put(JsonLdConsts.LANGUAGE, ((String) value).toLowerCase());
                 } else {
                     throw new JsonLdError(Error.INVALID_DEFAULT_LANGUAGE, value);
                 }
@@ -239,7 +239,7 @@ public class Context extends LinkedHashMap<String, Object> {
             // 3.7
             final Map<String, Boolean> defined = new LinkedHashMap<String, Boolean>();
             for (final String key : ((Map<String, Object>) context).keySet()) {
-                if ("@base".equals(key) || "@vocab".equals(key) || "@language".equals(key)) {
+                if (JsonLdConsts.BASE.equals(key) || JsonLdConsts.VOCAB.equals(key) || JsonLdConsts.LANGUAGE.equals(key)) {
                     continue;
                 }
                 result.createTermDefinition((Map<String, Object>) context, key, defined);
@@ -281,15 +281,15 @@ public class Context extends LinkedHashMap<String, Object> {
         this.termDefinitions.remove(term);
         Object value = context.get(term);
         if (value == null
-                || (value instanceof Map && ((Map<String, Object>) value).containsKey("@id") && ((Map<String, Object>) value)
-                        .get("@id") == null)) {
+                || (value instanceof Map && ((Map<String, Object>) value).containsKey(JsonLdConsts.ID) && ((Map<String, Object>) value)
+                        .get(JsonLdConsts.ID) == null)) {
             this.termDefinitions.put(term, null);
             defined.put(term, true);
             return;
         }
 
         if (value instanceof String) {
-            value = newMap("@id", value);
+            value = newMap(JsonLdConsts.ID, value);
         }
 
         if (!(value instanceof Map)) {
@@ -303,13 +303,13 @@ public class Context extends LinkedHashMap<String, Object> {
         final Map<String, Object> definition = newMap();
 
         // 10)
-        if (val.containsKey("@type")) {
-            if (!(val.get("@type") instanceof String)) {
-                throw new JsonLdError(Error.INVALID_TYPE_MAPPING, val.get("@type"));
+        if (val.containsKey(JsonLdConsts.TYPE)) {
+            if (!(val.get(JsonLdConsts.TYPE) instanceof String)) {
+                throw new JsonLdError(Error.INVALID_TYPE_MAPPING, val.get(JsonLdConsts.TYPE));
             }
-            String type = (String) val.get("@type");
+            String type = (String) val.get(JsonLdConsts.TYPE);
             try {
-                type = this.expandIri((String) val.get("@type"), false, true, context, defined);
+                type = this.expandIri((String) val.get(JsonLdConsts.TYPE), false, true, context, defined);
             } catch (final JsonLdError error) {
                 if (error.getType() != Error.INVALID_IRI_MAPPING) {
                     throw error;
@@ -318,64 +318,64 @@ public class Context extends LinkedHashMap<String, Object> {
             }
             // TODO: fix check for absoluteIri (blank nodes shouldn't count, at
             // least not here!)
-            if ("@id".equals(type) || "@vocab".equals(type)
-                    || (!type.startsWith("_:") && JsonLdUtils.isAbsoluteIri(type))) {
-                definition.put("@type", type);
+            if (JsonLdConsts.ID.equals(type) || JsonLdConsts.VOCAB.equals(type)
+                    || (!type.startsWith(JsonLdConsts.BLANK_NODE_PREFIX) && JsonLdUtils.isAbsoluteIri(type))) {
+                definition.put(JsonLdConsts.TYPE, type);
             } else {
                 throw new JsonLdError(Error.INVALID_TYPE_MAPPING, type);
             }
         }
 
         // 11)
-        if (val.containsKey("@reverse")) {
-            if (val.containsKey("@id")) {
+        if (val.containsKey(JsonLdConsts.REVERSE)) {
+            if (val.containsKey(JsonLdConsts.ID)) {
                 throw new JsonLdError(Error.INVALID_REVERSE_PROPERTY, val);
             }
-            if (!(val.get("@reverse") instanceof String)) {
+            if (!(val.get(JsonLdConsts.REVERSE) instanceof String)) {
                 throw new JsonLdError(Error.INVALID_IRI_MAPPING,
                         "Expected String for @reverse value. got "
-                                + (val.get("@reverse") == null ? "null" : val.get("@reverse")
+                                + (val.get(JsonLdConsts.REVERSE) == null ? "null" : val.get(JsonLdConsts.REVERSE)
                                         .getClass()));
             }
-            final String reverse = this.expandIri((String) val.get("@reverse"), false, true,
+            final String reverse = this.expandIri((String) val.get(JsonLdConsts.REVERSE), false, true,
                     context, defined);
             if (!JsonLdUtils.isAbsoluteIri(reverse)) {
                 throw new JsonLdError(Error.INVALID_IRI_MAPPING, "Non-absolute @reverse IRI: "
                         + reverse);
             }
-            definition.put("@id", reverse);
-            if (val.containsKey("@container")) {
-                final String container = (String) val.get("@container");
-                if (container == null || "@set".equals(container) || "@index".equals(container)) {
-                    definition.put("@container", container);
+            definition.put(JsonLdConsts.ID, reverse);
+            if (val.containsKey(JsonLdConsts.CONTAINER)) {
+                final String container = (String) val.get(JsonLdConsts.CONTAINER);
+                if (container == null || JsonLdConsts.SET.equals(container) || JsonLdConsts.INDEX.equals(container)) {
+                    definition.put(JsonLdConsts.CONTAINER, container);
                 } else {
                     throw new JsonLdError(Error.INVALID_REVERSE_PROPERTY,
                             "reverse properties only support set- and index-containers");
                 }
             }
-            definition.put("@reverse", true);
+            definition.put(JsonLdConsts.REVERSE, true);
             this.termDefinitions.put(term, definition);
             defined.put(term, true);
             return;
         }
 
         // 12)
-        definition.put("@reverse", false);
+        definition.put(JsonLdConsts.REVERSE, false);
 
         // 13)
-        if (val.get("@id") != null && !term.equals(val.get("@id"))) {
-            if (!(val.get("@id") instanceof String)) {
+        if (val.get(JsonLdConsts.ID) != null && !term.equals(val.get(JsonLdConsts.ID))) {
+            if (!(val.get(JsonLdConsts.ID) instanceof String)) {
                 throw new JsonLdError(Error.INVALID_IRI_MAPPING,
                         "expected value of @id to be a string");
             }
 
-            final String res = this.expandIri((String) val.get("@id"), false, true, context,
+            final String res = this.expandIri((String) val.get(JsonLdConsts.ID), false, true, context,
                     defined);
             if (JsonLdUtils.isKeyword(res) || JsonLdUtils.isAbsoluteIri(res)) {
-                if ("@context".equals(res)) {
+                if (JsonLdConsts.CONTEXT.equals(res)) {
                     throw new JsonLdError(Error.INVALID_KEYWORD_ALIAS, "cannot alias @context");
                 }
-                definition.put("@id", res);
+                definition.put(JsonLdConsts.ID, res);
             } else {
                 throw new JsonLdError(Error.INVALID_IRI_MAPPING,
                         "resulting IRI mapping should be a keyword, absolute IRI or blank node");
@@ -391,35 +391,35 @@ public class Context extends LinkedHashMap<String, Object> {
                 this.createTermDefinition(context, prefix, defined);
             }
             if (termDefinitions.containsKey(prefix)) {
-                definition.put("@id",
-                        ((Map<String, Object>) termDefinitions.get(prefix)).get("@id") + suffix);
+                definition.put(JsonLdConsts.ID,
+                        ((Map<String, Object>) termDefinitions.get(prefix)).get(JsonLdConsts.ID) + suffix);
             } else {
-                definition.put("@id", term);
+                definition.put(JsonLdConsts.ID, term);
             }
             // 15)
-        } else if (this.containsKey("@vocab")) {
-            definition.put("@id", this.get("@vocab") + term);
+        } else if (this.containsKey(JsonLdConsts.VOCAB)) {
+            definition.put(JsonLdConsts.ID, this.get(JsonLdConsts.VOCAB) + term);
         } else {
             throw new JsonLdError(Error.INVALID_IRI_MAPPING,
                     "relative term definition without vocab mapping");
         }
 
         // 16)
-        if (val.containsKey("@container")) {
-            final String container = (String) val.get("@container");
-            if (!"@list".equals(container) && !"@set".equals(container)
-                    && !"@index".equals(container) && !"@language".equals(container)) {
+        if (val.containsKey(JsonLdConsts.CONTAINER)) {
+            final String container = (String) val.get(JsonLdConsts.CONTAINER);
+            if (!JsonLdConsts.LIST.equals(container) && !JsonLdConsts.SET.equals(container)
+                    && !JsonLdConsts.INDEX.equals(container) && !JsonLdConsts.LANGUAGE.equals(container)) {
                 throw new JsonLdError(Error.INVALID_CONTAINER_MAPPING,
                         "@container must be either @list, @set, @index, or @language");
             }
-            definition.put("@container", container);
+            definition.put(JsonLdConsts.CONTAINER, container);
         }
 
         // 17)
-        if (val.containsKey("@language") && !val.containsKey("@type")) {
-            if (val.get("@language") == null || val.get("@language") instanceof String) {
-                final String language = (String) val.get("@language");
-                definition.put("@language", language != null ? language.toLowerCase() : null);
+        if (val.containsKey(JsonLdConsts.LANGUAGE) && !val.containsKey(JsonLdConsts.TYPE)) {
+            if (val.get(JsonLdConsts.LANGUAGE) == null || val.get(JsonLdConsts.LANGUAGE) instanceof String) {
+                final String language = (String) val.get(JsonLdConsts.LANGUAGE);
+                definition.put(JsonLdConsts.LANGUAGE, language != null ? language.toLowerCase() : null);
             } else {
                 throw new JsonLdError(Error.INVALID_LANGUAGE_MAPPING,
                         "@language must be a string or null");
@@ -460,7 +460,7 @@ public class Context extends LinkedHashMap<String, Object> {
             final Map<String, Object> td = (LinkedHashMap<String, Object>) this.termDefinitions
                     .get(value);
             if (td != null) {
-                return (String) td.get("@id");
+                return (String) td.get(JsonLdConsts.ID);
             } else {
                 return null;
             }
@@ -483,18 +483,18 @@ public class Context extends LinkedHashMap<String, Object> {
             // 4.4)
             if (this.termDefinitions.containsKey(prefix)) {
                 return (String) ((LinkedHashMap<String, Object>) this.termDefinitions.get(prefix))
-                        .get("@id") + suffix;
+                        .get(JsonLdConsts.ID) + suffix;
             }
             // 4.5)
             return value;
         }
         // 5)
-        if (vocab && this.containsKey("@vocab")) {
-            return this.get("@vocab") + value;
+        if (vocab && this.containsKey(JsonLdConsts.VOCAB)) {
+            return this.get(JsonLdConsts.VOCAB) + value;
         }
         // 6)
         else if (relative) {
-            return JsonLdUrl.resolve((String) this.get("@base"), value);
+            return JsonLdUrl.resolve((String) this.get(JsonLdConsts.BASE), value);
         } else if (context != null && JsonLdUtils.isRelativeIri(value)) {
             throw new JsonLdError(Error.INVALID_IRI_MAPPING, "not an absolute IRI: " + value);
         }
@@ -531,62 +531,62 @@ public class Context extends LinkedHashMap<String, Object> {
         // 2)
         if (relativeToVocab && getInverse().containsKey(iri)) {
             // 2.1)
-            String defaultLanguage = (String) this.get("@language");
+            String defaultLanguage = (String) this.get(JsonLdConsts.LANGUAGE);
             if (defaultLanguage == null) {
-                defaultLanguage = "@none";
+                defaultLanguage = JsonLdConsts.NONE;
             }
 
             // 2.2)
             final List<String> containers = new ArrayList<String>();
             // 2.3)
-            String typeLanguage = "@language";
-            String typeLanguageValue = "@null";
+            String typeLanguage = JsonLdConsts.LANGUAGE;
+            String typeLanguageValue = JsonLdConsts.NULL;
 
             // 2.4)
-            if (value instanceof Map && ((Map<String, Object>) value).containsKey("@index")) {
-                containers.add("@index");
+            if (value instanceof Map && ((Map<String, Object>) value).containsKey(JsonLdConsts.INDEX)) {
+                containers.add(JsonLdConsts.INDEX);
             }
 
             // 2.5)
             if (reverse) {
-                typeLanguage = "@type";
-                typeLanguageValue = "@reverse";
-                containers.add("@set");
+                typeLanguage = JsonLdConsts.TYPE;
+                typeLanguageValue = JsonLdConsts.REVERSE;
+                containers.add(JsonLdConsts.SET);
             }
             // 2.6)
-            else if (value instanceof Map && ((Map<String, Object>) value).containsKey("@list")) {
+            else if (value instanceof Map && ((Map<String, Object>) value).containsKey(JsonLdConsts.LIST)) {
                 // 2.6.1)
-                if (!((Map<String, Object>) value).containsKey("@index")) {
-                    containers.add("@list");
+                if (!((Map<String, Object>) value).containsKey(JsonLdConsts.INDEX)) {
+                    containers.add(JsonLdConsts.LIST);
                 }
                 // 2.6.2)
-                final List<Object> list = (List<Object>) ((Map<String, Object>) value).get("@list");
+                final List<Object> list = (List<Object>) ((Map<String, Object>) value).get(JsonLdConsts.LIST);
                 // 2.6.3)
                 String commonLanguage = (list.size() == 0) ? defaultLanguage : null;
                 String commonType = null;
                 // 2.6.4)
                 for (final Object item : list) {
                     // 2.6.4.1)
-                    String itemLanguage = "@none";
-                    String itemType = "@none";
+                    String itemLanguage = JsonLdConsts.NONE;
+                    String itemType = JsonLdConsts.NONE;
                     // 2.6.4.2)
                     if (JsonLdUtils.isValue(item)) {
                         // 2.6.4.2.1)
-                        if (((Map<String, Object>) item).containsKey("@language")) {
-                            itemLanguage = (String) ((Map<String, Object>) item).get("@language");
+                        if (((Map<String, Object>) item).containsKey(JsonLdConsts.LANGUAGE)) {
+                            itemLanguage = (String) ((Map<String, Object>) item).get(JsonLdConsts.LANGUAGE);
                         }
                         // 2.6.4.2.2)
-                        else if (((Map<String, Object>) item).containsKey("@type")) {
-                            itemType = (String) ((Map<String, Object>) item).get("@type");
+                        else if (((Map<String, Object>) item).containsKey(JsonLdConsts.TYPE)) {
+                            itemType = (String) ((Map<String, Object>) item).get(JsonLdConsts.TYPE);
                         }
                         // 2.6.4.2.3)
                         else {
-                            itemLanguage = "@null";
+                            itemLanguage = JsonLdConsts.NULL;
                         }
                     }
                     // 2.6.4.3)
                     else {
-                        itemType = "@id";
+                        itemType = JsonLdConsts.ID;
                     }
                     // 2.6.4.4)
                     if (commonLanguage == null) {
@@ -594,7 +594,7 @@ public class Context extends LinkedHashMap<String, Object> {
                     }
                     // 2.6.4.5)
                     else if (!commonLanguage.equals(itemLanguage) && JsonLdUtils.isValue(item)) {
-                        commonLanguage = "@none";
+                        commonLanguage = JsonLdConsts.NONE;
                     }
                     // 2.6.4.6)
                     if (commonType == null) {
@@ -602,20 +602,20 @@ public class Context extends LinkedHashMap<String, Object> {
                     }
                     // 2.6.4.7)
                     else if (!commonType.equals(itemType)) {
-                        commonType = "@none";
+                        commonType = JsonLdConsts.NONE;
                     }
                     // 2.6.4.8)
-                    if ("@none".equals(commonLanguage) && "@none".equals(commonType)) {
+                    if (JsonLdConsts.NONE.equals(commonLanguage) && JsonLdConsts.NONE.equals(commonType)) {
                         break;
                     }
                 }
                 // 2.6.5)
-                commonLanguage = (commonLanguage != null) ? commonLanguage : "@none";
+                commonLanguage = (commonLanguage != null) ? commonLanguage : JsonLdConsts.NONE;
                 // 2.6.6)
-                commonType = (commonType != null) ? commonType : "@none";
+                commonType = (commonType != null) ? commonType : JsonLdConsts.NONE;
                 // 2.6.7)
-                if (!"@none".equals(commonType)) {
-                    typeLanguage = "@type";
+                if (!JsonLdConsts.NONE.equals(commonType)) {
+                    typeLanguage = JsonLdConsts.TYPE;
                     typeLanguageValue = commonType;
                 }
                 // 2.6.8)
@@ -626,64 +626,64 @@ public class Context extends LinkedHashMap<String, Object> {
             // 2.7)
             else {
                 // 2.7.1)
-                if (value instanceof Map && ((Map<String, Object>) value).containsKey("@value")) {
+                if (value instanceof Map && ((Map<String, Object>) value).containsKey(JsonLdConsts.VALUE)) {
                     // 2.7.1.1)
-                    if (((Map<String, Object>) value).containsKey("@language")
-                            && !((Map<String, Object>) value).containsKey("@index")) {
-                        containers.add("@language");
-                        typeLanguageValue = (String) ((Map<String, Object>) value).get("@language");
+                    if (((Map<String, Object>) value).containsKey(JsonLdConsts.LANGUAGE)
+                            && !((Map<String, Object>) value).containsKey(JsonLdConsts.INDEX)) {
+                        containers.add(JsonLdConsts.LANGUAGE);
+                        typeLanguageValue = (String) ((Map<String, Object>) value).get(JsonLdConsts.LANGUAGE);
                     }
                     // 2.7.1.2)
-                    else if (((Map<String, Object>) value).containsKey("@type")) {
-                        typeLanguage = "@type";
-                        typeLanguageValue = (String) ((Map<String, Object>) value).get("@type");
+                    else if (((Map<String, Object>) value).containsKey(JsonLdConsts.TYPE)) {
+                        typeLanguage = JsonLdConsts.TYPE;
+                        typeLanguageValue = (String) ((Map<String, Object>) value).get(JsonLdConsts.TYPE);
                     }
                 }
                 // 2.7.2)
                 else {
-                    typeLanguage = "@type";
-                    typeLanguageValue = "@id";
+                    typeLanguage = JsonLdConsts.TYPE;
+                    typeLanguageValue = JsonLdConsts.ID;
                 }
                 // 2.7.3)
-                containers.add("@set");
+                containers.add(JsonLdConsts.SET);
             }
 
             // 2.8)
-            containers.add("@none");
+            containers.add(JsonLdConsts.NONE);
             // 2.9)
             if (typeLanguageValue == null) {
-                typeLanguageValue = "@null";
+                typeLanguageValue = JsonLdConsts.NULL;
             }
             // 2.10)
             final List<String> preferredValues = new ArrayList<String>();
             // 2.11)
-            if ("@reverse".equals(typeLanguageValue)) {
-                preferredValues.add("@reverse");
+            if (JsonLdConsts.REVERSE.equals(typeLanguageValue)) {
+                preferredValues.add(JsonLdConsts.REVERSE);
             }
             // 2.12)
-            if (("@reverse".equals(typeLanguageValue) || "@id".equals(typeLanguageValue))
-                    && (value instanceof Map) && ((Map<String, Object>) value).containsKey("@id")) {
+            if ((JsonLdConsts.REVERSE.equals(typeLanguageValue) || JsonLdConsts.ID.equals(typeLanguageValue))
+                    && (value instanceof Map) && ((Map<String, Object>) value).containsKey(JsonLdConsts.ID)) {
                 // 2.12.1)
                 final String result = this.compactIri(
-                        (String) ((Map<String, Object>) value).get("@id"), null, true, true);
+                        (String) ((Map<String, Object>) value).get(JsonLdConsts.ID), null, true, true);
                 if (termDefinitions.containsKey(result)
-                        && ((Map<String, Object>) termDefinitions.get(result)).containsKey("@id")
-                        && ((Map<String, Object>) value).get("@id").equals(
-                                ((Map<String, Object>) termDefinitions.get(result)).get("@id"))) {
-                    preferredValues.add("@vocab");
-                    preferredValues.add("@id");
+                        && ((Map<String, Object>) termDefinitions.get(result)).containsKey(JsonLdConsts.ID)
+                        && ((Map<String, Object>) value).get(JsonLdConsts.ID).equals(
+                                ((Map<String, Object>) termDefinitions.get(result)).get(JsonLdConsts.ID))) {
+                    preferredValues.add(JsonLdConsts.VOCAB);
+                    preferredValues.add(JsonLdConsts.ID);
                 }
                 // 2.12.2)
                 else {
-                    preferredValues.add("@id");
-                    preferredValues.add("@vocab");
+                    preferredValues.add(JsonLdConsts.ID);
+                    preferredValues.add(JsonLdConsts.VOCAB);
                 }
             }
             // 2.13)
             else {
                 preferredValues.add(typeLanguageValue);
             }
-            preferredValues.add("@none");
+            preferredValues.add(JsonLdConsts.NONE);
 
             // 2.14)
             final String term = selectTerm(iri, containers, typeLanguage, preferredValues);
@@ -694,9 +694,9 @@ public class Context extends LinkedHashMap<String, Object> {
         }
 
         // 3)
-        if (relativeToVocab && this.containsKey("@vocab")) {
+        if (relativeToVocab && this.containsKey(JsonLdConsts.VOCAB)) {
             // determine if vocab is a prefix of the iri
-            final String vocab = (String) this.get("@vocab");
+            final String vocab = (String) this.get(JsonLdConsts.VOCAB);
             // 3.1)
             if (iri.indexOf(vocab) == 0 && !iri.equals(vocab)) {
                 // use suffix as relative iri if it is not a term in the
@@ -719,14 +719,14 @@ public class Context extends LinkedHashMap<String, Object> {
                 continue;
             }
             // 5.2)
-            if (termDefinition == null || iri.equals(termDefinition.get("@id"))
-                    || !iri.startsWith((String) termDefinition.get("@id"))) {
+            if (termDefinition == null || iri.equals(termDefinition.get(JsonLdConsts.ID))
+                    || !iri.startsWith((String) termDefinition.get(JsonLdConsts.ID))) {
                 continue;
             }
 
             // 5.3)
             final String candidate = term + ":"
-                    + iri.substring(((String) termDefinition.get("@id")).length());
+                    + iri.substring(((String) termDefinition.get(JsonLdConsts.ID)).length());
             // 5.4)
             compactIRI = _iriCompactionStep5point4(iri, value, compactIRI, candidate, termDefinitions);
         }
@@ -738,7 +738,7 @@ public class Context extends LinkedHashMap<String, Object> {
 
         // 7)
         if (!relativeToVocab) {
-            return JsonLdUrl.removeBase(this.get("@base"), iri);
+            return JsonLdUrl.removeBase(this.get(JsonLdConsts.BASE), iri);
         }
 
         // 8)
@@ -755,7 +755,7 @@ public class Context extends LinkedHashMap<String, Object> {
         
         boolean condition2 = (!termDefinitions.containsKey(candidate) || (iri
                 .equals(((Map<String, Object>) termDefinitions.get(candidate))
-                        .get("@id")) && value == null));
+                        .get(JsonLdConsts.ID)) && value == null));
         
         if (condition1 && condition2) {
             compactIRI = candidate;
@@ -790,7 +790,7 @@ public class Context extends LinkedHashMap<String, Object> {
             if (termDefinition == null) {
                 continue;
             }
-            final String id = (String) termDefinition.get("@id");
+            final String id = (String) termDefinition.get(JsonLdConsts.ID);
             if (id == null) {
                 continue;
             }
@@ -842,9 +842,9 @@ public class Context extends LinkedHashMap<String, Object> {
         inverse = newMap();
 
         // 2)
-        String defaultLanguage = (String) this.get("@language");
+        String defaultLanguage = (String) this.get(JsonLdConsts.LANGUAGE);
         if (defaultLanguage == null) {
-            defaultLanguage = "@none";
+            defaultLanguage = JsonLdConsts.NONE;
         }
 
         // create term selections for each mapping in the context, ordererd by
@@ -865,13 +865,13 @@ public class Context extends LinkedHashMap<String, Object> {
             }
 
             // 3.2)
-            String container = (String) definition.get("@container");
+            String container = (String) definition.get(JsonLdConsts.CONTAINER);
             if (container == null) {
-                container = "@none";
+                container = JsonLdConsts.NONE;
             }
 
             // 3.3)
-            final String iri = (String) definition.get("@id");
+            final String iri = (String) definition.get(JsonLdConsts.ID);
 
             // 3.4 + 3.5)
             Map<String, Object> containerMap = (Map<String, Object>) inverse.get(iri);
@@ -884,32 +884,32 @@ public class Context extends LinkedHashMap<String, Object> {
             Map<String, Object> typeLanguageMap = (Map<String, Object>) containerMap.get(container);
             if (typeLanguageMap == null) {
                 typeLanguageMap = newMap();
-                typeLanguageMap.put("@language", newMap());
-                typeLanguageMap.put("@type", newMap());
+                typeLanguageMap.put(JsonLdConsts.LANGUAGE, newMap());
+                typeLanguageMap.put(JsonLdConsts.TYPE, newMap());
                 containerMap.put(container, typeLanguageMap);
             }
 
             // 3.8)
-            if (Boolean.TRUE.equals(definition.get("@reverse"))) {
+            if (Boolean.TRUE.equals(definition.get(JsonLdConsts.REVERSE))) {
                 final Map<String, Object> typeMap = (Map<String, Object>) typeLanguageMap
-                        .get("@type");
-                if (!typeMap.containsKey("@reverse")) {
-                    typeMap.put("@reverse", term);
+                        .get(JsonLdConsts.TYPE);
+                if (!typeMap.containsKey(JsonLdConsts.REVERSE)) {
+                    typeMap.put(JsonLdConsts.REVERSE, term);
                 }
                 // 3.9)
-            } else if (definition.containsKey("@type")) {
+            } else if (definition.containsKey(JsonLdConsts.TYPE)) {
                 final Map<String, Object> typeMap = (Map<String, Object>) typeLanguageMap
-                        .get("@type");
-                if (!typeMap.containsKey(definition.get("@type"))) {
-                    typeMap.put((String) definition.get("@type"), term);
+                        .get(JsonLdConsts.TYPE);
+                if (!typeMap.containsKey(definition.get(JsonLdConsts.TYPE))) {
+                    typeMap.put((String) definition.get(JsonLdConsts.TYPE), term);
                 }
                 // 3.10)
-            } else if (definition.containsKey("@language")) {
+            } else if (definition.containsKey(JsonLdConsts.LANGUAGE)) {
                 final Map<String, Object> languageMap = (Map<String, Object>) typeLanguageMap
-                        .get("@language");
-                String language = (String) definition.get("@language");
+                        .get(JsonLdConsts.LANGUAGE);
+                String language = (String) definition.get(JsonLdConsts.LANGUAGE);
                 if (language == null) {
-                    language = "@null";
+                    language = JsonLdConsts.NULL;
                 }
                 if (!languageMap.containsKey(language)) {
                     languageMap.put(language, term);
@@ -918,21 +918,21 @@ public class Context extends LinkedHashMap<String, Object> {
             } else {
                 // 3.11.1)
                 final Map<String, Object> languageMap = (Map<String, Object>) typeLanguageMap
-                        .get("@language");
+                        .get(JsonLdConsts.LANGUAGE);
                 // 3.11.2)
-                if (!languageMap.containsKey("@language")) {
-                    languageMap.put("@language", term);
+                if (!languageMap.containsKey(JsonLdConsts.LANGUAGE)) {
+                    languageMap.put(JsonLdConsts.LANGUAGE, term);
                 }
                 // 3.11.3)
-                if (!languageMap.containsKey("@none")) {
-                    languageMap.put("@none", term);
+                if (!languageMap.containsKey(JsonLdConsts.NONE)) {
+                    languageMap.put(JsonLdConsts.NONE, term);
                 }
                 // 3.11.4)
                 final Map<String, Object> typeMap = (Map<String, Object>) typeLanguageMap
-                        .get("@type");
+                        .get(JsonLdConsts.TYPE);
                 // 3.11.5)
-                if (!typeMap.containsKey("@none")) {
-                    typeMap.put("@none", term);
+                if (!typeMap.containsKey(JsonLdConsts.NONE)) {
+                    typeMap.put(JsonLdConsts.NONE, term);
                 }
             }
         }
@@ -992,8 +992,8 @@ public class Context extends LinkedHashMap<String, Object> {
      * @return The container mapping
      */
     public String getContainer(String property) {
-        if ("@graph".equals(property)) {
-            return "@set";
+        if (JsonLdConsts.GRAPH.equals(property)) {
+            return JsonLdConsts.SET;
         }
         if (JsonLdUtils.isKeyword(property)) {
             return property;
@@ -1002,7 +1002,7 @@ public class Context extends LinkedHashMap<String, Object> {
         if (td == null) {
             return null;
         }
-        return (String) td.get("@container");
+        return (String) td.get(JsonLdConsts.CONTAINER);
     }
 
     public Boolean isReverseProperty(String property) {
@@ -1010,7 +1010,7 @@ public class Context extends LinkedHashMap<String, Object> {
         if (td == null) {
             return false;
         }
-        final Object reverse = td.get("@reverse");
+        final Object reverse = td.get(JsonLdConsts.REVERSE);
         return reverse != null && (Boolean) reverse;
     }
 
@@ -1019,7 +1019,7 @@ public class Context extends LinkedHashMap<String, Object> {
         if (td == null) {
             return null;
         }
-        return (String) td.get("@type");
+        return (String) td.get(JsonLdConsts.TYPE);
     }
 
     private String getLanguageMapping(String property) {
@@ -1027,7 +1027,7 @@ public class Context extends LinkedHashMap<String, Object> {
         if (td == null) {
             return null;
         }
-        return (String) td.get("@language");
+        return (String) td.get(JsonLdConsts.LANGUAGE);
     }
 
     Map<String, Object> getTermDefinition(String key) {
@@ -1038,36 +1038,36 @@ public class Context extends LinkedHashMap<String, Object> {
         final Map<String, Object> rval = newMap();
         final Map<String, Object> td = getTermDefinition(activeProperty);
         // 1)
-        if (td != null && "@id".equals(td.get("@type"))) {
+        if (td != null && JsonLdConsts.ID.equals(td.get(JsonLdConsts.TYPE))) {
             // TODO: i'm pretty sure value should be a string if the @type is
             // @id
-            rval.put("@id", expandIri(value.toString(), true, false, null, null));
+            rval.put(JsonLdConsts.ID, expandIri(value.toString(), true, false, null, null));
             return rval;
         }
         // 2)
-        if (td != null && "@vocab".equals(td.get("@type"))) {
+        if (td != null && JsonLdConsts.VOCAB.equals(td.get(JsonLdConsts.TYPE))) {
             // TODO: same as above
-            rval.put("@id", expandIri(value.toString(), true, true, null, null));
+            rval.put(JsonLdConsts.ID, expandIri(value.toString(), true, true, null, null));
             return rval;
         }
         // 3)
-        rval.put("@value", value);
+        rval.put(JsonLdConsts.VALUE, value);
         // 4)
-        if (td != null && td.containsKey("@type")) {
-            rval.put("@type", td.get("@type"));
+        if (td != null && td.containsKey(JsonLdConsts.TYPE)) {
+            rval.put(JsonLdConsts.TYPE, td.get(JsonLdConsts.TYPE));
         }
         // 5)
         else if (value instanceof String) {
             // 5.1)
-            if (td != null && td.containsKey("@language")) {
-                final String lang = (String) td.get("@language");
+            if (td != null && td.containsKey(JsonLdConsts.LANGUAGE)) {
+                final String lang = (String) td.get(JsonLdConsts.LANGUAGE);
                 if (lang != null) {
-                    rval.put("@language", lang);
+                    rval.put(JsonLdConsts.LANGUAGE, lang);
                 }
             }
             // 5.2)
-            else if (this.get("@language") != null) {
-                rval.put("@language", this.get("@language"));
+            else if (this.get(JsonLdConsts.LANGUAGE) != null) {
+                rval.put(JsonLdConsts.LANGUAGE, this.get(JsonLdConsts.LANGUAGE));
             }
         }
         return rval;
@@ -1080,42 +1080,42 @@ public class Context extends LinkedHashMap<String, Object> {
 
     public Map<String, Object> serialize() {
         final Map<String, Object> ctx = newMap();
-        if (this.get("@base") != null && !this.get("@base").equals(options.getBase())) {
-            ctx.put("@base", this.get("@base"));
+        if (this.get(JsonLdConsts.BASE) != null && !this.get(JsonLdConsts.BASE).equals(options.getBase())) {
+            ctx.put(JsonLdConsts.BASE, this.get(JsonLdConsts.BASE));
         }
-        if (this.get("@language") != null) {
-            ctx.put("@language", this.get("@language"));
+        if (this.get(JsonLdConsts.LANGUAGE) != null) {
+            ctx.put(JsonLdConsts.LANGUAGE, this.get(JsonLdConsts.LANGUAGE));
         }
-        if (this.get("@vocab") != null) {
-            ctx.put("@vocab", this.get("@vocab"));
+        if (this.get(JsonLdConsts.VOCAB) != null) {
+            ctx.put(JsonLdConsts.VOCAB, this.get(JsonLdConsts.VOCAB));
         }
         for (final String term : termDefinitions.keySet()) {
             final Map<String, Object> definition = (Map<String, Object>) termDefinitions.get(term);
-            if (definition.get("@language") == null
-                    && definition.get("@container") == null
-                    && definition.get("@type") == null
-                    && (definition.get("@reverse") == null || Boolean.FALSE.equals(definition
-                            .get("@reverse")))) {
-                final String cid = this.compactIri((String) definition.get("@id"));
-                ctx.put(term, term.equals(cid) ? definition.get("@id") : cid);
+            if (definition.get(JsonLdConsts.LANGUAGE) == null
+                    && definition.get(JsonLdConsts.CONTAINER) == null
+                    && definition.get(JsonLdConsts.TYPE) == null
+                    && (definition.get(JsonLdConsts.REVERSE) == null || Boolean.FALSE.equals(definition
+                            .get(JsonLdConsts.REVERSE)))) {
+                final String cid = this.compactIri((String) definition.get(JsonLdConsts.ID));
+                ctx.put(term, term.equals(cid) ? definition.get(JsonLdConsts.ID) : cid);
             } else {
                 final Map<String, Object> defn = newMap();
-                final String cid = this.compactIri((String) definition.get("@id"));
-                final Boolean reverseProperty = Boolean.TRUE.equals(definition.get("@reverse"));
+                final String cid = this.compactIri((String) definition.get(JsonLdConsts.ID));
+                final Boolean reverseProperty = Boolean.TRUE.equals(definition.get(JsonLdConsts.REVERSE));
                 if (!(term.equals(cid) && !reverseProperty)) {
-                    defn.put(reverseProperty ? "@reverse" : "@id", cid);
+                    defn.put(reverseProperty ? JsonLdConsts.REVERSE : JsonLdConsts.ID, cid);
                 }
-                final String typeMapping = (String) definition.get("@type");
+                final String typeMapping = (String) definition.get(JsonLdConsts.TYPE);
                 if (typeMapping != null) {
-                    defn.put("@type", JsonLdUtils.isKeyword(typeMapping) ? typeMapping
+                    defn.put(JsonLdConsts.TYPE, JsonLdUtils.isKeyword(typeMapping) ? typeMapping
                             : compactIri(typeMapping, true));
                 }
-                if (definition.get("@container") != null) {
-                    defn.put("@container", definition.get("@container"));
+                if (definition.get(JsonLdConsts.CONTAINER) != null) {
+                    defn.put(JsonLdConsts.CONTAINER, definition.get(JsonLdConsts.CONTAINER));
                 }
-                final Object lang = definition.get("@language");
-                if (definition.get("@language") != null) {
-                    defn.put("@language", Boolean.FALSE.equals(lang) ? null : lang);
+                final Object lang = definition.get(JsonLdConsts.LANGUAGE);
+                if (definition.get(JsonLdConsts.LANGUAGE) != null) {
+                    defn.put(JsonLdConsts.LANGUAGE, Boolean.FALSE.equals(lang) ? null : lang);
                 }
                 ctx.put(term, defn);
             }
@@ -1123,7 +1123,7 @@ public class Context extends LinkedHashMap<String, Object> {
 
         final Map<String, Object> rval = newMap();
         if (!(ctx == null || ctx.isEmpty())) {
-            rval.put("@context", ctx);
+            rval.put(JsonLdConsts.CONTEXT, ctx);
         }
         return rval;
     }

--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -134,6 +134,7 @@ public class Context extends LinkedHashMap<String, Object> {
      * @throws JsonLdError
      *             If there is an error parsing the contexts.
      */
+    @SuppressWarnings("unchecked")
     public Context parse(Object localContext, List<String> remoteContexts) throws JsonLdError {
         if (remoteContexts == null) {
             remoteContexts = new ArrayList<String>();
@@ -187,13 +188,17 @@ public class Context extends LinkedHashMap<String, Object> {
 
             // 3.4
             if (remoteContexts.isEmpty() && ((Map<String, Object>) context).containsKey(JsonLdConsts.BASE)) {
+                // 3.4.1
                 final Object value = ((Map<String, Object>) context).get(JsonLdConsts.BASE);
+                // 3.4.2
                 if (value == null) {
                     result.remove(JsonLdConsts.BASE);
                 } else if (value instanceof String) {
+                    // 3.4.3
                     if (JsonLdUtils.isAbsoluteIri((String) value)) {
                         result.put(JsonLdConsts.BASE, value);
                     } else {
+                        // 3.4.4
                         final String baseUri = (String) result.get(JsonLdConsts.BASE);
                         if (!JsonLdUtils.isAbsoluteIri(baseUri)) {
                             throw new JsonLdError(Error.INVALID_BASE_IRI, baseUri);
@@ -201,6 +206,7 @@ public class Context extends LinkedHashMap<String, Object> {
                         result.put(JsonLdConsts.BASE, JsonLdUrl.resolve(baseUri, (String) value));
                     }
                 } else {
+                    // 3.4.5
                     throw new JsonLdError(JsonLdError.Error.INVALID_BASE_IRI,
                             "@base must be a string");
                 }

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -182,14 +182,14 @@ public class JsonLdApi {
             final Map<String, Object> elem = (Map<String, Object>) element;
 
             // 4
-            if (elem.containsKey("@value") || elem.containsKey("@id")) {
+            if (elem.containsKey(JsonLdConsts.VALUE) || elem.containsKey(JsonLdConsts.ID)) {
                 final Object compactedValue = activeCtx.compactValue(activeProperty, elem);
                 if (!(compactedValue instanceof Map || compactedValue instanceof List)) {
                     return compactedValue;
                 }
             }
             // 5)
-            final boolean insideReverse = ("@reverse".equals(activeProperty));
+            final boolean insideReverse = (JsonLdConsts.REVERSE.equals(activeProperty));
 
             // 6)
             final Map<String, Object> result = newMap();
@@ -200,13 +200,13 @@ public class JsonLdApi {
                 final Object expandedValue = elem.get(expandedProperty);
 
                 // 7.1)
-                if ("@id".equals(expandedProperty) || "@type".equals(expandedProperty)) {
+                if (JsonLdConsts.ID.equals(expandedProperty) || JsonLdConsts.TYPE.equals(expandedProperty)) {
                     Object compactedValue;
 
                     // 7.1.1)
                     if (expandedValue instanceof String) {
                         compactedValue = activeCtx.compactIri((String) expandedValue,
-                                "@type".equals(expandedProperty));
+                                JsonLdConsts.TYPE.equals(expandedProperty));
                     }
                     // 7.1.2)
                     else {
@@ -235,10 +235,10 @@ public class JsonLdApi {
                 }
 
                 // 7.2)
-                if ("@reverse".equals(expandedProperty)) {
+                if (JsonLdConsts.REVERSE.equals(expandedProperty)) {
                     // 7.2.1)
                     final Map<String, Object> compactedValue = (Map<String, Object>) compact(
-                            activeCtx, "@reverse", expandedValue, compactArrays);
+                            activeCtx, JsonLdConsts.REVERSE, expandedValue, compactArrays);
 
                     // 7.2.2)
                     // Note: Must create a new set to avoid modifying the set we
@@ -248,7 +248,7 @@ public class JsonLdApi {
                         // 7.2.2.1)
                         if (activeCtx.isReverseProperty(property)) {
                             // 7.2.2.1.1)
-                            if (("@set".equals(activeCtx.getContainer(property)) || !compactArrays)
+                            if ((JsonLdConsts.SET.equals(activeCtx.getContainer(property)) || !compactArrays)
                                     && !(value instanceof List)) {
                                 final List<Object> tmp = new ArrayList<Object>();
                                 tmp.add(value);
@@ -278,7 +278,7 @@ public class JsonLdApi {
                     // 7.2.3)
                     if (!compactedValue.isEmpty()) {
                         // 7.2.3.1)
-                        final String alias = activeCtx.compactIri("@reverse", true);
+                        final String alias = activeCtx.compactIri(JsonLdConsts.REVERSE, true);
                         // 7.2.3.2)
                         result.put(alias, compactedValue);
                     }
@@ -287,13 +287,13 @@ public class JsonLdApi {
                 }
 
                 // 7.3)
-                if ("@index".equals(expandedProperty)
-                        && "@index".equals(activeCtx.getContainer(activeProperty))) {
+                if (JsonLdConsts.INDEX.equals(expandedProperty)
+                        && JsonLdConsts.INDEX.equals(activeCtx.getContainer(activeProperty))) {
                     continue;
                 }
                 // 7.4)
-                else if ("@index".equals(expandedProperty) || "@value".equals(expandedProperty)
-                        || "@language".equals(expandedProperty)) {
+                else if (JsonLdConsts.INDEX.equals(expandedProperty) || JsonLdConsts.VALUE.equals(expandedProperty)
+                        || JsonLdConsts.LANGUAGE.equals(expandedProperty)) {
                     // 7.4.1)
                     final String alias = activeCtx.compactIri(expandedProperty, true);
                     // 7.4.2)
@@ -332,10 +332,10 @@ public class JsonLdApi {
 
                     // get @list value if appropriate
                     final boolean isList = (expandedItem instanceof Map && ((Map<String, Object>) expandedItem)
-                            .containsKey("@list"));
+                            .containsKey(JsonLdConsts.LIST));
                     Object list = null;
                     if (isList) {
-                        list = ((Map<String, Object>) expandedItem).get("@list");
+                        list = ((Map<String, Object>) expandedItem).get(JsonLdConsts.LIST);
                     }
 
                     // 7.6.3)
@@ -351,20 +351,20 @@ public class JsonLdApi {
                             compactedItem = tmp;
                         }
                         // 7.6.4.2)
-                        if (!"@list".equals(container)) {
+                        if (!JsonLdConsts.LIST.equals(container)) {
                             // 7.6.4.2.1)
                             final Map<String, Object> wrapper = newMap();
                             // TODO: SPEC: no mention of vocab = true
-                            wrapper.put(activeCtx.compactIri("@list", true), compactedItem);
+                            wrapper.put(activeCtx.compactIri(JsonLdConsts.LIST, true), compactedItem);
                             compactedItem = wrapper;
 
                             // 7.6.4.2.2)
-                            if (((Map<String, Object>) expandedItem).containsKey("@index")) {
+                            if (((Map<String, Object>) expandedItem).containsKey(JsonLdConsts.INDEX)) {
                                 ((Map<String, Object>) compactedItem).put(
                                         // TODO: SPEC: no mention of vocab =
                                         // true
-                                        activeCtx.compactIri("@index", true),
-                                        ((Map<String, Object>) expandedItem).get("@index"));
+                                        activeCtx.compactIri(JsonLdConsts.INDEX, true),
+                                        ((Map<String, Object>) expandedItem).get(JsonLdConsts.INDEX));
                             }
                         }
                         // 7.6.4.3)
@@ -375,7 +375,7 @@ public class JsonLdApi {
                     }
 
                     // 7.6.5)
-                    if ("@language".equals(container) || "@index".equals(container)) {
+                    if (JsonLdConsts.LANGUAGE.equals(container) || JsonLdConsts.INDEX.equals(container)) {
                         // 7.6.5.1)
                         Map<String, Object> mapObject;
                         if (result.containsKey(itemActiveProperty)) {
@@ -386,10 +386,10 @@ public class JsonLdApi {
                         }
 
                         // 7.6.5.2)
-                        if ("@language".equals(container)
+                        if (JsonLdConsts.LANGUAGE.equals(container)
                                 && (compactedItem instanceof Map && ((Map<String, Object>) compactedItem)
-                                        .containsKey("@value"))) {
-                            compactedItem = ((Map<String, Object>) compactedItem).get("@value");
+                                        .containsKey(JsonLdConsts.VALUE))) {
+                            compactedItem = ((Map<String, Object>) compactedItem).get(JsonLdConsts.VALUE);
                         }
 
                         // 7.6.5.3)
@@ -412,8 +412,8 @@ public class JsonLdApi {
                     // 7.6.6)
                     else {
                         // 7.6.6.1)
-                        final Boolean check = (!compactArrays || "@set".equals(container)
-                                || "@list".equals(container) || "@list".equals(expandedProperty) || "@graph"
+                        final Boolean check = (!compactArrays || JsonLdConsts.SET.equals(container)
+                                || JsonLdConsts.LIST.equals(container) || JsonLdConsts.LIST.equals(expandedProperty) || JsonLdConsts.GRAPH
                                     .equals(expandedProperty))
                                 && (!(compactedItem instanceof List));
                         if (check) {
@@ -507,10 +507,10 @@ public class JsonLdApi {
                 // 3.2.1)
                 final Object v = expand(activeCtx, activeProperty, item);
                 // 3.2.2)
-                if (("@list".equals(activeProperty) || "@list".equals(activeCtx
+                if ((JsonLdConsts.LIST.equals(activeProperty) || JsonLdConsts.LIST.equals(activeCtx
                         .getContainer(activeProperty)))
                         && (v instanceof List || (v instanceof Map && ((Map<String, Object>) v)
-                                .containsKey("@list")))) {
+                                .containsKey(JsonLdConsts.LIST)))) {
                     throw new JsonLdError(Error.LIST_OF_LISTS, "lists of lists are not permitted.");
                 }
                 // 3.2.3)
@@ -530,8 +530,8 @@ public class JsonLdApi {
             // access helper
             final Map<String, Object> elem = (Map<String, Object>) element;
             // 5)
-            if (elem.containsKey("@context")) {
-                activeCtx = activeCtx.parse(elem.get("@context"));
+            if (elem.containsKey(JsonLdConsts.CONTEXT)) {
+                activeCtx = activeCtx.parse(elem.get(JsonLdConsts.CONTEXT));
             }
             // 6)
             Map<String, Object> result = newMap();
@@ -541,7 +541,7 @@ public class JsonLdApi {
             for (final String key : keys) {
                 final Object value = elem.get(key);
                 // 7.1)
-                if (key.equals("@context")) {
+                if (key.equals(JsonLdConsts.CONTEXT)) {
                     continue;
                 }
                 // 7.2)
@@ -555,7 +555,7 @@ public class JsonLdApi {
                 // 7.4)
                 if (isKeyword(expandedProperty)) {
                     // 7.4.1)
-                    if ("@reverse".equals(activeProperty)) {
+                    if (JsonLdConsts.REVERSE.equals(activeProperty)) {
                         throw new JsonLdError(Error.INVALID_REVERSE_PROPERTY_MAP,
                                 "a keyword cannot be used as a @reverse propery");
                     }
@@ -565,7 +565,7 @@ public class JsonLdApi {
                                 + " already exists in result");
                     }
                     // 7.4.3)
-                    if ("@id".equals(expandedProperty)) {
+                    if (JsonLdConsts.ID.equals(expandedProperty)) {
                         if (!(value instanceof String)) {
                             throw new JsonLdError(Error.INVALID_ID_VALUE,
                                     "value of @id must be a string");
@@ -574,7 +574,7 @@ public class JsonLdApi {
                                 .expandIri((String) value, true, false, null, null);
                     }
                     // 7.4.4)
-                    else if ("@type".equals(expandedProperty)) {
+                    else if (JsonLdConsts.TYPE.equals(expandedProperty)) {
                         if (value instanceof List) {
                             expandedValue = new ArrayList<String>();
                             for (final Object v : (List) value) {
@@ -602,23 +602,23 @@ public class JsonLdApi {
                         }
                     }
                     // 7.4.5)
-                    else if ("@graph".equals(expandedProperty)) {
-                        expandedValue = expand(activeCtx, "@graph", value);
+                    else if (JsonLdConsts.GRAPH.equals(expandedProperty)) {
+                        expandedValue = expand(activeCtx, JsonLdConsts.GRAPH, value);
                     }
                     // 7.4.6)
-                    else if ("@value".equals(expandedProperty)) {
+                    else if (JsonLdConsts.VALUE.equals(expandedProperty)) {
                         if (value != null && (value instanceof Map || value instanceof List)) {
                             throw new JsonLdError(Error.INVALID_VALUE_OBJECT_VALUE, "value of "
                                     + expandedProperty + " must be a scalar or null");
                         }
                         expandedValue = value;
                         if (expandedValue == null) {
-                            result.put("@value", null);
+                            result.put(JsonLdConsts.VALUE, null);
                             continue;
                         }
                     }
                     // 7.4.7)
-                    else if ("@language".equals(expandedProperty)) {
+                    else if (JsonLdConsts.LANGUAGE.equals(expandedProperty)) {
                         if (!(value instanceof String)) {
                             throw new JsonLdError(Error.INVALID_LANGUAGE_TAGGED_STRING, "Value of "
                                     + expandedProperty + " must be a string");
@@ -626,7 +626,7 @@ public class JsonLdApi {
                         expandedValue = ((String) value).toLowerCase();
                     }
                     // 7.4.8)
-                    else if ("@index".equals(expandedProperty)) {
+                    else if (JsonLdConsts.INDEX.equals(expandedProperty)) {
                         if (!(value instanceof String)) {
                             throw new JsonLdError(Error.INVALID_INDEX_VALUE, "Value of "
                                     + expandedProperty + " must be a string");
@@ -634,9 +634,9 @@ public class JsonLdApi {
                         expandedValue = value;
                     }
                     // 7.4.9)
-                    else if ("@list".equals(expandedProperty)) {
+                    else if (JsonLdConsts.LIST.equals(expandedProperty)) {
                         // 7.4.9.1)
-                        if (activeProperty == null || "@graph".equals(activeProperty)) {
+                        if (activeProperty == null || JsonLdConsts.GRAPH.equals(activeProperty)) {
                             continue;
                         }
                         // 7.4.9.2)
@@ -651,29 +651,29 @@ public class JsonLdApi {
 
                         // 7.4.9.3)
                         for (final Object o : (List<Object>) expandedValue) {
-                            if (o instanceof Map && ((Map<String, Object>) o).containsKey("@list")) {
+                            if (o instanceof Map && ((Map<String, Object>) o).containsKey(JsonLdConsts.LIST)) {
                                 throw new JsonLdError(Error.LIST_OF_LISTS,
                                         "A list may not contain another list");
                             }
                         }
                     }
                     // 7.4.10)
-                    else if ("@set".equals(expandedProperty)) {
+                    else if (JsonLdConsts.SET.equals(expandedProperty)) {
                         expandedValue = expand(activeCtx, activeProperty, value);
                     }
                     // 7.4.11)
-                    else if ("@reverse".equals(expandedProperty)) {
+                    else if (JsonLdConsts.REVERSE.equals(expandedProperty)) {
                         if (!(value instanceof Map)) {
                             throw new JsonLdError(Error.INVALID_REVERSE_VALUE,
                                     "@reverse value must be an object");
                         }
                         // 7.4.11.1)
-                        expandedValue = expand(activeCtx, "@reverse", value);
+                        expandedValue = expand(activeCtx, JsonLdConsts.REVERSE, value);
                         // NOTE: algorithm assumes the result is a map
                         // 7.4.11.2)
-                        if (((Map<String, Object>) expandedValue).containsKey("@reverse")) {
+                        if (((Map<String, Object>) expandedValue).containsKey(JsonLdConsts.REVERSE)) {
                             final Map<String, Object> reverse = (Map<String, Object>) ((Map<String, Object>) expandedValue)
-                                    .get("@reverse");
+                                    .get(JsonLdConsts.REVERSE);
                             for (final String property : reverse.keySet()) {
                                 final Object item = reverse.get(property);
                                 // 7.4.11.2.1)
@@ -691,18 +691,18 @@ public class JsonLdApi {
                         }
                         // 7.4.11.3)
                         if (((Map<String, Object>) expandedValue).size() > (((Map<String, Object>) expandedValue)
-                                .containsKey("@reverse") ? 1 : 0)) {
+                                .containsKey(JsonLdConsts.REVERSE) ? 1 : 0)) {
                             // 7.4.11.3.1)
-                            if (!result.containsKey("@reverse")) {
-                                result.put("@reverse", newMap());
+                            if (!result.containsKey(JsonLdConsts.REVERSE)) {
+                                result.put(JsonLdConsts.REVERSE, newMap());
                             }
                             // 7.4.11.3.2)
                             final Map<String, Object> reverseMap = (Map<String, Object>) result
-                                    .get("@reverse");
+                                    .get(JsonLdConsts.REVERSE);
                             // 7.4.11.3.3)
                             for (final String property : ((Map<String, Object>) expandedValue)
                                     .keySet()) {
-                                if ("@reverse".equals(property)) {
+                                if (JsonLdConsts.REVERSE.equals(property)) {
                                     continue;
                                 }
                                 // 7.4.11.3.3.1)
@@ -711,8 +711,8 @@ public class JsonLdApi {
                                 for (final Object item : items) {
                                     // 7.4.11.3.3.1.1)
                                     if (item instanceof Map
-                                            && (((Map<String, Object>) item).containsKey("@value") || ((Map<String, Object>) item)
-                                                    .containsKey("@list"))) {
+                                            && (((Map<String, Object>) item).containsKey(JsonLdConsts.VALUE) || ((Map<String, Object>) item)
+                                                    .containsKey(JsonLdConsts.LIST))) {
                                         throw new JsonLdError(Error.INVALID_REVERSE_PROPERTY_VALUE);
                                     }
                                     // 7.4.11.3.3.1.2)
@@ -728,11 +728,11 @@ public class JsonLdApi {
                         continue;
                     }
                     // TODO: SPEC no mention of @explicit etc in spec
-                    else if ("@explicit".equals(expandedProperty)
-                            || "@default".equals(expandedProperty)
-                            || "@embed".equals(expandedProperty)
-                            || "@embedChildren".equals(expandedProperty)
-                            || "@omitDefault".equals(expandedProperty)) {
+                    else if (JsonLdConsts.EXPLICIT.equals(expandedProperty)
+                            || JsonLdConsts.DEFAULT.equals(expandedProperty)
+                            || JsonLdConsts.EMBED.equals(expandedProperty)
+                            || JsonLdConsts.EMBED_CHILDREN.equals(expandedProperty)
+                            || JsonLdConsts.OMIT_DEFAULT.equals(expandedProperty)) {
                         expandedValue = expand(activeCtx, expandedProperty, value);
                     }
                     // 7.4.12)
@@ -743,7 +743,7 @@ public class JsonLdApi {
                     continue;
                 }
                 // 7.5
-                else if ("@language".equals(activeCtx.getContainer(key)) && value instanceof Map) {
+                else if (JsonLdConsts.LANGUAGE.equals(activeCtx.getContainer(key)) && value instanceof Map) {
                     // 7.5.1)
                     expandedValue = new ArrayList<Object>();
                     // 7.5.2)
@@ -764,14 +764,14 @@ public class JsonLdApi {
                             }
                             // 7.5.2.2.2)
                             final Map<String, Object> tmp = newMap();
-                            tmp.put("@value", item);
-                            tmp.put("@language", language.toLowerCase());
+                            tmp.put(JsonLdConsts.VALUE, item);
+                            tmp.put(JsonLdConsts.LANGUAGE, language.toLowerCase());
                             ((List<Object>) expandedValue).add(tmp);
                         }
                     }
                 }
                 // 7.6)
-                else if ("@index".equals(activeCtx.getContainer(key)) && value instanceof Map) {
+                else if (JsonLdConsts.INDEX.equals(activeCtx.getContainer(key)) && value instanceof Map) {
                     // 7.6.1)
                     expandedValue = new ArrayList<Object>();
                     // 7.6.2)
@@ -791,8 +791,8 @@ public class JsonLdApi {
                         // 7.6.2.3)
                         for (final Map<String, Object> item : (List<Map<String, Object>>) indexValue) {
                             // 7.6.2.3.1)
-                            if (!item.containsKey("@index")) {
-                                item.put("@index", index);
+                            if (!item.containsKey(JsonLdConsts.INDEX)) {
+                                item.put(JsonLdConsts.INDEX, index);
                             }
                             // 7.6.2.3.2)
                             ((List<Object>) expandedValue).add(item);
@@ -808,27 +808,27 @@ public class JsonLdApi {
                     continue;
                 }
                 // 7.9)
-                if ("@list".equals(activeCtx.getContainer(key))) {
+                if (JsonLdConsts.LIST.equals(activeCtx.getContainer(key))) {
                     if (!(expandedValue instanceof Map)
-                            || !((Map<String, Object>) expandedValue).containsKey("@list")) {
+                            || !((Map<String, Object>) expandedValue).containsKey(JsonLdConsts.LIST)) {
                         Object tmp = expandedValue;
                         if (!(tmp instanceof List)) {
                             tmp = new ArrayList<Object>();
                             ((List<Object>) tmp).add(expandedValue);
                         }
                         expandedValue = newMap();
-                        ((Map<String, Object>) expandedValue).put("@list", tmp);
+                        ((Map<String, Object>) expandedValue).put(JsonLdConsts.LIST, tmp);
                     }
                 }
                 // 7.10)
                 if (activeCtx.isReverseProperty(key)) {
                     // 7.10.1)
-                    if (!result.containsKey("@reverse")) {
-                        result.put("@reverse", newMap());
+                    if (!result.containsKey(JsonLdConsts.REVERSE)) {
+                        result.put(JsonLdConsts.REVERSE, newMap());
                     }
                     // 7.10.2)
                     final Map<String, Object> reverseMap = (Map<String, Object>) result
-                            .get("@reverse");
+                            .get(JsonLdConsts.REVERSE);
                     // 7.10.3)
                     if (!(expandedValue instanceof List)) {
                         final Object tmp = expandedValue;
@@ -839,8 +839,8 @@ public class JsonLdApi {
                     for (final Object item : (List<Object>) expandedValue) {
                         // 7.10.4.1)
                         if (item instanceof Map
-                                && (((Map<String, Object>) item).containsKey("@value") || ((Map<String, Object>) item)
-                                        .containsKey("@list"))) {
+                                && (((Map<String, Object>) item).containsKey(JsonLdConsts.VALUE) || ((Map<String, Object>) item)
+                                        .containsKey(JsonLdConsts.LIST))) {
                             throw new JsonLdError(Error.INVALID_REVERSE_PROPERTY_VALUE);
                         }
                         // 7.10.4.2)
@@ -872,82 +872,82 @@ public class JsonLdApi {
                 }
             }
             // 8)
-            if (result.containsKey("@value")) {
+            if (result.containsKey(JsonLdConsts.VALUE)) {
                 // 8.1)
                 // TODO: is this method faster than just using containsKey for
                 // each?
                 final Set<String> keySet = new HashSet(result.keySet());
-                keySet.remove("@value");
-                keySet.remove("@index");
-                final boolean langremoved = keySet.remove("@language");
-                final boolean typeremoved = keySet.remove("@type");
+                keySet.remove(JsonLdConsts.VALUE);
+                keySet.remove(JsonLdConsts.INDEX);
+                final boolean langremoved = keySet.remove(JsonLdConsts.LANGUAGE);
+                final boolean typeremoved = keySet.remove(JsonLdConsts.TYPE);
                 if ((langremoved && typeremoved) || !keySet.isEmpty()) {
                     throw new JsonLdError(Error.INVALID_VALUE_OBJECT,
                             "value object has unknown keys");
                 }
                 // 8.2)
-                final Object rval = result.get("@value");
+                final Object rval = result.get(JsonLdConsts.VALUE);
                 if (rval == null) {
                     // nothing else is possible with result if we set it to
                     // null, so simply return it
                     return null;
                 }
                 // 8.3)
-                if (!(rval instanceof String) && result.containsKey("@language")) {
+                if (!(rval instanceof String) && result.containsKey(JsonLdConsts.LANGUAGE)) {
                     throw new JsonLdError(Error.INVALID_LANGUAGE_TAGGED_VALUE,
                             "when @language is used, @value must be a string");
                 }
                 // 8.4)
-                else if (result.containsKey("@type")) {
+                else if (result.containsKey(JsonLdConsts.TYPE)) {
                     // TODO: is this enough for "is an IRI"
-                    if (!(result.get("@type") instanceof String)
-                            || ((String) result.get("@type")).startsWith("_:")
-                            || !((String) result.get("@type")).contains(":")) {
+                    if (!(result.get(JsonLdConsts.TYPE) instanceof String)
+                            || ((String) result.get(JsonLdConsts.TYPE)).startsWith("_:")
+                            || !((String) result.get(JsonLdConsts.TYPE)).contains(":")) {
                         throw new JsonLdError(Error.INVALID_TYPED_VALUE,
                                 "value of @type must be an IRI");
                     }
                 }
             }
             // 9)
-            else if (result.containsKey("@type")) {
-                final Object rtype = result.get("@type");
+            else if (result.containsKey(JsonLdConsts.TYPE)) {
+                final Object rtype = result.get(JsonLdConsts.TYPE);
                 if (!(rtype instanceof List)) {
                     final List<Object> tmp = new ArrayList<Object>();
                     tmp.add(rtype);
-                    result.put("@type", tmp);
+                    result.put(JsonLdConsts.TYPE, tmp);
                 }
             }
             // 10)
-            else if (result.containsKey("@set") || result.containsKey("@list")) {
+            else if (result.containsKey(JsonLdConsts.SET) || result.containsKey(JsonLdConsts.LIST)) {
                 // 10.1)
-                if (result.size() > (result.containsKey("@index") ? 2 : 1)) {
+                if (result.size() > (result.containsKey(JsonLdConsts.INDEX) ? 2 : 1)) {
                     throw new JsonLdError(Error.INVALID_SET_OR_LIST_OBJECT,
                             "@set or @list may only contain @index");
                 }
                 // 10.2)
-                if (result.containsKey("@set")) {
+                if (result.containsKey(JsonLdConsts.SET)) {
                     // result becomes an array here, thus the remaining checks
                     // will never be true from here on
                     // so simply return the value rather than have to make
                     // result an object and cast it with every
                     // other use in the function.
-                    return result.get("@set");
+                    return result.get(JsonLdConsts.SET);
                 }
             }
             // 11)
-            if (result.containsKey("@language") && result.size() == 1) {
+            if (result.containsKey(JsonLdConsts.LANGUAGE) && result.size() == 1) {
                 result = null;
             }
             // 12)
-            if (activeProperty == null || "@graph".equals(activeProperty)) {
+            if (activeProperty == null || JsonLdConsts.GRAPH.equals(activeProperty)) {
                 // 12.1)
                 if (result != null
-                        && (result.size() == 0 || result.containsKey("@value") || result
-                                .containsKey("@list"))) {
+                        && (result.size() == 0 || result.containsKey(JsonLdConsts.VALUE) || result
+                                .containsKey(JsonLdConsts.LIST))) {
                     result = null;
                 }
                 // 12.2)
-                else if (result != null && result.containsKey("@id") && result.size() == 1) {
+                else if (result != null && result.containsKey(JsonLdConsts.ID) && result.size() == 1) {
                     result = null;
                 }
             }
@@ -957,7 +957,7 @@ public class JsonLdApi {
         // 2) If element is a scalar
         else {
             // 2.1)
-            if (activeProperty == null || "@graph".equals(activeProperty)) {
+            if (activeProperty == null || JsonLdConsts.GRAPH.equals(activeProperty)) {
                 return null;
             }
             return activeCtx.expandValue(activeProperty, element);
@@ -990,7 +990,7 @@ public class JsonLdApi {
      */
 
     void generateNodeMap(Object element, Map<String, Object> nodeMap) throws JsonLdError {
-        generateNodeMap(element, nodeMap, "@default", null, null, null);
+        generateNodeMap(element, nodeMap, JsonLdConsts.DEFAULT, null, null, null);
     }
 
     void generateNodeMap(Object element, Map<String, Object> nodeMap, String activeGraph)
@@ -1022,15 +1022,15 @@ public class JsonLdApi {
                 .get(activeSubject));
 
         // 3)
-        if (elem.containsKey("@type")) {
+        if (elem.containsKey(JsonLdConsts.TYPE)) {
             // 3.1)
             List<String> oldTypes;
             final List<String> newTypes = new ArrayList<String>();
-            if (elem.get("@type") instanceof List) {
-                oldTypes = (List<String>) elem.get("@type");
+            if (elem.get(JsonLdConsts.TYPE) instanceof List) {
+                oldTypes = (List<String>) elem.get(JsonLdConsts.TYPE);
             } else {
                 oldTypes = new ArrayList<String>();
-                oldTypes.add((String) elem.get("@type"));
+                oldTypes.add((String) elem.get(JsonLdConsts.TYPE));
             }
             for (final String item : oldTypes) {
                 if (item.startsWith("_:")) {
@@ -1039,35 +1039,35 @@ public class JsonLdApi {
                     newTypes.add(item);
                 }
             }
-            if (elem.get("@type") instanceof List) {
-                elem.put("@type", newTypes);
+            if (elem.get(JsonLdConsts.TYPE) instanceof List) {
+                elem.put(JsonLdConsts.TYPE, newTypes);
             } else {
-                elem.put("@type", newTypes.get(0));
+                elem.put(JsonLdConsts.TYPE, newTypes.get(0));
             }
         }
 
         // 4)
-        if (elem.containsKey("@value")) {
+        if (elem.containsKey(JsonLdConsts.VALUE)) {
             // 4.1)
             if (list == null) {
                 JsonLdUtils.mergeValue(node, activeProperty, elem);
             }
             // 4.2)
             else {
-                JsonLdUtils.mergeValue(list, "@list", elem);
+                JsonLdUtils.mergeValue(list, JsonLdConsts.LIST, elem);
             }
         }
 
         // 5)
-        else if (elem.containsKey("@list")) {
+        else if (elem.containsKey(JsonLdConsts.LIST)) {
             // 5.1)
-            final Map<String, Object> result = newMap("@list", new ArrayList<Object>());
+            final Map<String, Object> result = newMap(JsonLdConsts.LIST, new ArrayList<Object>());
             // 5.2)
             // for (final Object item : (List<Object>) elem.get("@list")) {
             // generateNodeMap(item, nodeMap, activeGraph, activeSubject,
             // activeProperty, result);
             // }
-            generateNodeMap(elem.get("@list"), nodeMap, activeGraph, activeSubject, activeProperty,
+            generateNodeMap(elem.get(JsonLdConsts.LIST), nodeMap, activeGraph, activeSubject, activeProperty,
                     result);
             // 5.3)
             JsonLdUtils.mergeValue(node, activeProperty, result);
@@ -1076,7 +1076,7 @@ public class JsonLdApi {
         // 6)
         else {
             // 6.1)
-            String id = (String) elem.remove("@id");
+            String id = (String) elem.remove(JsonLdConsts.ID);
             if (id != null) {
                 if (id.startsWith("_:")) {
                     id = generateBlankNodeIdentifier(id);
@@ -1088,7 +1088,7 @@ public class JsonLdApi {
             }
             // 6.3)
             if (!graph.containsKey(id)) {
-                final Map<String, Object> tmp = newMap("@id", id);
+                final Map<String, Object> tmp = newMap(JsonLdConsts.ID, id);
                 graph.put(id, tmp);
             }
             // 6.4) TODO: SPEC this line is asked for by the spec, but it breaks
@@ -1102,7 +1102,7 @@ public class JsonLdApi {
             }
             // 6.6)
             else if (activeProperty != null) {
-                final Map<String, Object> reference = newMap("@id", id);
+                final Map<String, Object> reference = newMap(JsonLdConsts.ID, id);
                 // 6.6.2)
                 if (list == null) {
                     // 6.6.2.1+2)
@@ -1111,36 +1111,36 @@ public class JsonLdApi {
                 // 6.6.3) TODO: SPEC says to add ELEMENT to @list member, should
                 // be REFERENCE
                 else {
-                    JsonLdUtils.mergeValue(list, "@list", reference);
+                    JsonLdUtils.mergeValue(list, JsonLdConsts.LIST, reference);
                 }
             }
             // TODO: SPEC this is removed in the spec now, but it's still needed
             // (see 6.4)
             node = (Map<String, Object>) graph.get(id);
             // 6.7)
-            if (elem.containsKey("@type")) {
-                for (final Object type : (List<Object>) elem.remove("@type")) {
-                    JsonLdUtils.mergeValue(node, "@type", type);
+            if (elem.containsKey(JsonLdConsts.TYPE)) {
+                for (final Object type : (List<Object>) elem.remove(JsonLdConsts.TYPE)) {
+                    JsonLdUtils.mergeValue(node, JsonLdConsts.TYPE, type);
                 }
             }
             // 6.8)
-            if (elem.containsKey("@index")) {
-                final Object elemIndex = elem.remove("@index");
-                if (node.containsKey("@index")) {
-                    if (!JsonLdUtils.deepCompare(node.get("@index"), elemIndex)) {
+            if (elem.containsKey(JsonLdConsts.INDEX)) {
+                final Object elemIndex = elem.remove(JsonLdConsts.INDEX);
+                if (node.containsKey(JsonLdConsts.INDEX)) {
+                    if (!JsonLdUtils.deepCompare(node.get(JsonLdConsts.INDEX), elemIndex)) {
                         throw new JsonLdError(Error.CONFLICTING_INDEXES);
                     }
                 } else {
-                    node.put("@index", elemIndex);
+                    node.put(JsonLdConsts.INDEX, elemIndex);
                 }
             }
             // 6.9)
-            if (elem.containsKey("@reverse")) {
+            if (elem.containsKey(JsonLdConsts.REVERSE)) {
                 // 6.9.1)
-                final Map<String, Object> referencedNode = newMap("@id", id);
+                final Map<String, Object> referencedNode = newMap(JsonLdConsts.ID, id);
                 // 6.9.2+6.9.4)
                 final Map<String, Object> reverseMap = (Map<String, Object>) elem
-                        .remove("@reverse");
+                        .remove(JsonLdConsts.REVERSE);
                 // 6.9.3)
                 for (final String property : reverseMap.keySet()) {
                     final List<Object> values = (List<Object>) reverseMap.get(property);
@@ -1152,8 +1152,8 @@ public class JsonLdApi {
                 }
             }
             // 6.10)
-            if (elem.containsKey("@graph")) {
-                generateNodeMap(elem.remove("@graph"), nodeMap, id, null, null, null);
+            if (elem.containsKey(JsonLdConsts.GRAPH)) {
+                generateNodeMap(elem.remove(JsonLdConsts.GRAPH), nodeMap, id, null, null, null);
             }
             // 6.11)
             final List<String> keys = new ArrayList<String>(elem.keySet());
@@ -1286,7 +1286,7 @@ public class JsonLdApi {
         // use tree map so keys are sotred by default
         final Map<String, Object> nodes = new TreeMap<String, Object>();
         generateNodeMap(input, nodes);
-        this.nodeMap = (Map<String, Object>) nodes.get("@default");
+        this.nodeMap = (Map<String, Object>) nodes.get(JsonLdConsts.DEFAULT);
 
         final List<Object> framed = new ArrayList<Object>();
         // NOTE: frame validation is done by the function not allowing anything
@@ -1322,8 +1322,8 @@ public class JsonLdApi {
         final Map<String, Object> matches = filterNodes(state, nodes, frame);
 
         // get flags for current frame
-        Boolean embedOn = getFrameFlag(frame, "@embed", state.embed);
-        final Boolean explicicOn = getFrameFlag(frame, "@explicit", state.explicit);
+        Boolean embedOn = getFrameFlag(frame, JsonLdConsts.EMBED, state.embed);
+        final Boolean explicicOn = getFrameFlag(frame, JsonLdConsts.EXPLICIT, state.explicit);
 
         // add matches to output
         final List<String> ids = new ArrayList<String>(matches.keySet());
@@ -1335,7 +1335,7 @@ public class JsonLdApi {
 
             // start output
             final Map<String, Object> output = newMap();
-            output.put("@id", id);
+            output.put(JsonLdConsts.ID, id);
 
             // prepare embed meta info
             final EmbedNode embeddedNode = new EmbedNode();
@@ -1361,7 +1361,7 @@ public class JsonLdApi {
                         for (final Object v : (List<Object>) ((Map<String, Object>) existing.parent)
                                 .get(existing.property)) {
                             if (v instanceof Map
-                                    && Obj.equals(id, ((Map<String, Object>) v).get("@id"))) {
+                                    && Obj.equals(id, ((Map<String, Object>) v).get(JsonLdConsts.ID))) {
                                 embedOn = true;
                                 break;
                             }
@@ -1410,30 +1410,30 @@ public class JsonLdApi {
 
                         // recurse into list
                         if ((item instanceof Map)
-                                && ((Map<String, Object>) item).containsKey("@list")) {
+                                && ((Map<String, Object>) item).containsKey(JsonLdConsts.LIST)) {
                             // add empty list
                             final Map<String, Object> list = newMap();
-                            list.put("@list", new ArrayList<Object>());
+                            list.put(JsonLdConsts.LIST, new ArrayList<Object>());
                             addFrameOutput(state, output, prop, list);
 
                             // add list objects
                             for (final Object listitem : (List<Object>) ((Map<String, Object>) item)
-                                    .get("@list")) {
+                                    .get(JsonLdConsts.LIST)) {
                                 // recurse into subject reference
                                 if (JsonLdUtils.isNodeReference(listitem)) {
                                     final Map<String, Object> tmp = newMap();
                                     final String itemid = (String) ((Map<String, Object>) listitem)
-                                            .get("@id");
+                                            .get(JsonLdConsts.ID);
                                     // TODO: nodes may need to be node_map,
                                     // which is global
                                     tmp.put(itemid, this.nodeMap.get(itemid));
                                     frame(state, tmp,
                                             (Map<String, Object>) ((List<Object>) frame.get(prop))
-                                                    .get(0), list, "@list");
+                                                    .get(0), list, JsonLdConsts.LIST);
                                 } else {
                                     // include other values automatcially (TODO:
                                     // may need JsonLdUtils.clone(n))
-                                    addFrameOutput(state, list, "@list", listitem);
+                                    addFrameOutput(state, list, JsonLdConsts.LIST, listitem);
                                 }
                             }
                         }
@@ -1441,7 +1441,7 @@ public class JsonLdApi {
                         // recurse into subject reference
                         else if (JsonLdUtils.isNodeReference(item)) {
                             final Map<String, Object> tmp = newMap();
-                            final String itemid = (String) ((Map<String, Object>) item).get("@id");
+                            final String itemid = (String) ((Map<String, Object>) item).get(JsonLdConsts.ID);
                             // TODO: nodes may need to be node_map, which is
                             // global
                             tmp.put(itemid, this.nodeMap.get(itemid));
@@ -1471,19 +1471,19 @@ public class JsonLdApi {
                     if (propertyFrame == null) {
                         propertyFrame = newMap();
                     }
-                    final boolean omitDefaultOn = getFrameFlag(propertyFrame, "@omitDefault",
+                    final boolean omitDefaultOn = getFrameFlag(propertyFrame, JsonLdConsts.OMIT_DEFAULT,
                             state.omitDefault);
                     if (!omitDefaultOn && !output.containsKey(prop)) {
                         Object def = "@null";
-                        if (propertyFrame.containsKey("@default")) {
-                            def = JsonLdUtils.clone(propertyFrame.get("@default"));
+                        if (propertyFrame.containsKey(JsonLdConsts.DEFAULT)) {
+                            def = JsonLdUtils.clone(propertyFrame.get(JsonLdConsts.DEFAULT));
                         }
                         if (!(def instanceof List)) {
                             final List<Object> tmp = new ArrayList<Object>();
                             tmp.add(def);
                             def = tmp;
                         }
-                        final Map<String, Object> tmp1 = newMap("@preserve", def);
+                        final Map<String, Object> tmp1 = newMap(JsonLdConsts.PRESERVE, def);
                         final List<Object> tmp2 = new ArrayList<Object>();
                         tmp2.add(tmp1);
                         output.put(prop, tmp2);
@@ -1503,8 +1503,8 @@ public class JsonLdApi {
                 value = ((List<Object>) value).get(0);
             }
         }
-        if (value instanceof Map && ((Map<String, Object>) value).containsKey("@value")) {
-            value = ((Map<String, Object>) value).get("@value");
+        if (value instanceof Map && ((Map<String, Object>) value).containsKey(JsonLdConsts.VALUE)) {
+            value = ((Map<String, Object>) value).get(JsonLdConsts.VALUE);
         }
         if (value instanceof Boolean) {
             return (Boolean) value;
@@ -1528,7 +1528,7 @@ public class JsonLdApi {
         final String property = embed.property;
 
         // create reference to replace embed
-        final Map<String, Object> node = newMap("@id", id);
+        final Map<String, Object> node = newMap(JsonLdConsts.ID, id);
 
         // remove existing embed
         if (JsonLdUtils.isNode(parent)) {
@@ -1537,7 +1537,7 @@ public class JsonLdApi {
             final List<Object> oldvals = (List<Object>) ((Map<String, Object>) parent)
                     .get(property);
             for (final Object v : oldvals) {
-                if (v instanceof Map && Obj.equals(((Map<String, Object>) v).get("@id"), id)) {
+                if (v instanceof Map && Obj.equals(((Map<String, Object>) v).get(JsonLdConsts.ID), id)) {
                     newvals.add(node);
                 } else {
                     newvals.add(v);
@@ -1557,7 +1557,7 @@ public class JsonLdApi {
             if (!(p instanceof Map)) {
                 continue;
             }
-            final String pid = (String) ((Map<String, Object>) p).get("@id");
+            final String pid = (String) ((Map<String, Object>) p).get(JsonLdConsts.ID);
             if (Obj.equals(id, pid)) {
                 embeds.remove(id_dep);
                 removeDependents(embeds, id_dep);
@@ -1579,12 +1579,12 @@ public class JsonLdApi {
 
     private boolean filterNode(FramingContext state, Map<String, Object> node,
             Map<String, Object> frame) throws JsonLdError {
-        final Object types = frame.get("@type");
+        final Object types = frame.get(JsonLdConsts.TYPE);
         if (types != null) {
             if (!(types instanceof List)) {
                 throw new JsonLdError(Error.SYNTAX_ERROR, "frame @type must be an array");
             }
-            Object nodeTypes = node.get("@type");
+            Object nodeTypes = node.get(JsonLdConsts.TYPE);
             if (nodeTypes == null) {
                 nodeTypes = new ArrayList<Object>();
             } else if (!(nodeTypes instanceof List)) {
@@ -1605,7 +1605,7 @@ public class JsonLdApi {
             }
         } else {
             for (final String key : frame.keySet()) {
-                if ("@id".equals(key) || !isKeyword(key) && !(node.containsKey(key))) {
+                if (JsonLdConsts.ID.equals(key) || !isKeyword(key) && !(node.containsKey(key))) {
 
                     Object frameObject = frame.get(key);
                     if (frameObject instanceof ArrayList) {
@@ -1614,7 +1614,7 @@ public class JsonLdApi {
                         boolean _default = false;
                         for (Object oo : o) {
                             if (oo instanceof Map) {
-                                if (((Map) oo).containsKey("@default")) {
+                                if (((Map) oo).containsKey(JsonLdConsts.DEFAULT)) {
                                     _default = true;
                                 }
                             }
@@ -1676,7 +1676,7 @@ public class JsonLdApi {
         for (Object o : objects) {
             // handle subject reference
             if (JsonLdUtils.isNodeReference(o)) {
-                final String sid = (String) ((Map<String, Object>) o).get("@id");
+                final String sid = (String) ((Map<String, Object>) o).get(JsonLdConsts.ID);
 
                 // embed full subject if isn't already embedded
                 if (!state.embeds.containsKey(sid)) {
@@ -1690,7 +1690,7 @@ public class JsonLdApi {
                     o = newMap();
                     Map<String, Object> s = (Map<String, Object>) this.nodeMap.get(sid);
                     if (s == null) {
-                        s = newMap("@id", sid);
+                        s = newMap(JsonLdConsts.ID, sid);
                     }
                     for (final String prop : s.keySet()) {
                         // copy keywords
@@ -1743,7 +1743,7 @@ public class JsonLdApi {
 
         public NodeMapNode(String id) {
             super();
-            this.put("@id", id);
+            this.put(JsonLdConsts.ID, id);
         }
 
         // helper fucntion for 4.3.3
@@ -1764,15 +1764,15 @@ public class JsonLdApi {
                     return false;
                 }
             }
-            if (containsKey("@type")) {
+            if (containsKey(JsonLdConsts.TYPE)) {
                 keys++;
-                if (!(get("@type") instanceof List && ((List<Object>) get("@type")).size() == 1)
-                        && RDF_LIST.equals(((List<Object>) get("@type")).get(0))) {
+                if (!(get(JsonLdConsts.TYPE) instanceof List && ((List<Object>) get(JsonLdConsts.TYPE)).size() == 1)
+                        && RDF_LIST.equals(((List<Object>) get(JsonLdConsts.TYPE)).get(0))) {
                     return false;
                 }
             }
             // TODO: SPEC: 4.3.3 has no mention of @id
-            if (containsKey("@id")) {
+            if (containsKey(JsonLdConsts.ID)) {
                 keys++;
             }
             if (keys < size()) {
@@ -1801,7 +1801,7 @@ public class JsonLdApi {
         final Map<String, NodeMapNode> defaultGraph = new LinkedHashMap<String, NodeMapNode>();
         // 2)
         final Map<String, Map<String, NodeMapNode>> graphMap = new LinkedHashMap<String, Map<String, NodeMapNode>>();
-        graphMap.put("@default", defaultGraph);
+        graphMap.put(JsonLdConsts.DEFAULT, defaultGraph);
 
         // 3/3.1)
         for (final String name : dataset.graphNames()) {
@@ -1818,7 +1818,7 @@ public class JsonLdApi {
             }
 
             // 3.3)
-            if (!"@default".equals(name) && !Obj.contains(defaultGraph, name)) {
+            if (!JsonLdConsts.DEFAULT.equals(name) && !Obj.contains(defaultGraph, name)) {
                 defaultGraph.put(name, new NodeMapNode(name));
             }
 
@@ -1846,7 +1846,7 @@ public class JsonLdApi {
                 // 3.5.4)
                 if (RDF_TYPE.equals(predicate) && (object.isIRI() || object.isBlankNode())
                         && !opts.getUseRdfType()) {
-                    JsonLdUtils.mergeValue(node, "@type", object.getValue());
+                    JsonLdUtils.mergeValue(node, JsonLdConsts.TYPE, object.getValue());
                     continue;
                 }
 
@@ -1890,7 +1890,7 @@ public class JsonLdApi {
                     // 4.3.3.1)
                     list.add(((List<Object>) node.get(RDF_FIRST)).get(0));
                     // 4.3.3.2)
-                    listNodes.add((String) node.get("@id"));
+                    listNodes.add((String) node.get(JsonLdConsts.ID));
                     // 4.3.3.3)
                     final UsagesNode nodeUsage = node.usages.get(0);
                     // 4.3.3.4)
@@ -1905,11 +1905,11 @@ public class JsonLdApi {
                 // 4.3.4)
                 if (RDF_FIRST.equals(property)) {
                     // 4.3.4.1)
-                    if (RDF_NIL.equals(node.get("@id"))) {
+                    if (RDF_NIL.equals(node.get(JsonLdConsts.ID))) {
                         continue;
                     }
                     // 4.3.4.3)
-                    final String headId = (String) head.get("@id");
+                    final String headId = (String) head.get(JsonLdConsts.ID);
                     // 4.3.4.4-5)
                     head = (Map<String, Object>) ((List<Object>) graph.get(headId).get(RDF_REST))
                             .get(0);
@@ -1918,11 +1918,11 @@ public class JsonLdApi {
                     listNodes.remove(listNodes.size() - 1);
                 }
                 // 4.3.5)
-                head.remove("@id");
+                head.remove(JsonLdConsts.ID);
                 // 4.3.6)
                 Collections.reverse(list);
                 // 4.3.7)
-                head.put("@list", list);
+                head.put(JsonLdConsts.LIST, list);
                 // 4.3.8)
                 for (final String nodeId : listNodes) {
                     graph.remove(nodeId);
@@ -1940,20 +1940,20 @@ public class JsonLdApi {
             // 6.1)
             if (graphMap.containsKey(subject)) {
                 // 6.1.1)
-                node.put("@graph", new ArrayList<Object>());
+                node.put(JsonLdConsts.GRAPH, new ArrayList<Object>());
                 // 6.1.2)
                 final List<String> keys = new ArrayList<String>(graphMap.get(subject).keySet());
                 Collections.sort(keys);
                 for (final String s : keys) {
                     final NodeMapNode n = graphMap.get(subject).get(s);
-                    if (n.size() == 1 && n.containsKey("@id")) {
+                    if (n.size() == 1 && n.containsKey(JsonLdConsts.ID)) {
                         continue;
                     }
-                    ((List<Object>) node.get("@graph")).add(n.serialize());
+                    ((List<Object>) node.get(JsonLdConsts.GRAPH)).add(n.serialize());
                 }
             }
             // 6.2)
-            if (node.size() == 1 && node.containsKey("@id")) {
+            if (node.size() == 1 && node.containsKey(JsonLdConsts.ID)) {
                 continue;
             }
             result.add(node.serialize());
@@ -1984,7 +1984,7 @@ public class JsonLdApi {
         // TODO: make the default generateNodeMap call (i.e. without a
         // graphName) create and return the nodeMap
         final Map<String, Object> nodeMap = newMap();
-        nodeMap.put("@default", newMap());
+        nodeMap.put(JsonLdConsts.DEFAULT, newMap());
         generateNodeMap(this.value, nodeMap);
 
         final RDFDataset dataset = new RDFDataset(this);
@@ -2027,7 +2027,7 @@ public class JsonLdApi {
         for (String graphName : dataset.keySet()) {
             final List<Map<String, Object>> triples = (List<Map<String, Object>>) dataset
                     .get(graphName);
-            if ("@default".equals(graphName)) {
+            if (JsonLdConsts.DEFAULT.equals(graphName)) {
                 graphName = null;
             }
             for (final Map<String, Object> quad : triples) {

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdConsts.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdConsts.java
@@ -27,4 +27,34 @@ public final class JsonLdConsts {
     public static final String RDF_OBJECT = RDF_SYNTAX_NS + "object";
     public static final String RDF_LANGSTRING = RDF_SYNTAX_NS + "langString";
     public static final String RDF_LIST = RDF_SYNTAX_NS + "List";
+    
+    public static final String TEXT_TURTLE = "text/turtle";
+    public static final String APPLICATION_NQUADS = "application/nquads";
+    
+    public static final String FLATTENED = "flattened";
+    public static final String COMPACTED = "compacted";
+    public static final String EXPANDED = "expanded";
+    
+    public static final String ID = "@id";
+    public static final String DEFAULT = "@default";
+    public static final String GRAPH = "@graph";
+    public static final String CONTEXT = "@context";
+    public static final String PRESERVE = "@preserve";
+    public static final String EXPLICIT = "@explicit";
+    public static final String OMIT_DEFAULT = "@omitDefault";
+    public static final String EMBED_CHILDREN = "@embedChildren";
+    public static final String EMBED = "@embed";
+    public static final String LIST = "@list";
+    public static final String LANGUAGE = "@language";
+    public static final String INDEX = "@index";
+    public static final String SET = "@set";
+    public static final String TYPE = "@type";
+    public static final String REVERSE = "@reverse";
+    public static final String VALUE = "@value";
+    public static final String NULL = "@null";
+    public static final String NONE = "@none";
+    public static final String CONTAINER = "@container";
+    public static final String BLANK_NODE_PREFIX = "_:";
+    public static final String VOCAB = "@vocab";
+    public static final String BASE = "@base";
 }

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
@@ -50,8 +50,8 @@ public class JsonLdProcessor {
         // 2-6) NOTE: these are all the same steps as in expand
         final Object expanded = expand(input, opts);
         // 7)
-        if (context instanceof Map && ((Map<String, Object>) context).containsKey("@context")) {
-            context = ((Map<String, Object>) context).get("@context");
+        if (context instanceof Map && ((Map<String, Object>) context).containsKey(JsonLdConsts.CONTEXT)) {
+            context = ((Map<String, Object>) context).get(JsonLdConsts.CONTEXT);
         }
         Context activeCtx = new Context(opts);
         activeCtx = activeCtx.parse(context);
@@ -67,7 +67,7 @@ public class JsonLdProcessor {
             } else {
                 final Map<String, Object> tmp = newMap();
                 // TODO: SPEC: doesn't specify to use vocab = true here
-                tmp.put(activeCtx.compactIri("@graph", true), compacted);
+                tmp.put(activeCtx.compactIri(JsonLdConsts.GRAPH, true), compacted);
                 compacted = tmp;
             }
         }
@@ -79,10 +79,10 @@ public class JsonLdProcessor {
 
                 if (context instanceof List && ((List<Object>) context).size() == 1
                         && opts.getCompactArrays()) {
-                    ((Map<String, Object>) compacted).put("@context",
+                    ((Map<String, Object>) compacted).put(JsonLdConsts.CONTEXT,
                             ((List<Object>) context).get(0));
                 } else {
-                    ((Map<String, Object>) compacted).put("@context", context);
+                    ((Map<String, Object>) compacted).put(JsonLdConsts.CONTEXT, context);
                 }
             }
         }
@@ -132,8 +132,8 @@ public class JsonLdProcessor {
         // 4)
         if (opts.getExpandContext() != null) {
             Object exCtx = opts.getExpandContext();
-            if (exCtx instanceof Map && ((Map<String, Object>) exCtx).containsKey("@context")) {
-                exCtx = ((Map<String, Object>) exCtx).get("@context");
+            if (exCtx instanceof Map && ((Map<String, Object>) exCtx).containsKey(JsonLdConsts.CONTEXT)) {
+                exCtx = ((Map<String, Object>) exCtx).get(JsonLdConsts.CONTEXT);
             }
             activeCtx = activeCtx.parse(exCtx);
         }
@@ -146,9 +146,9 @@ public class JsonLdProcessor {
         Object expanded = new JsonLdApi(opts).expand(activeCtx, input);
 
         // final step of Expansion Algorithm
-        if (expanded instanceof Map && ((Map) expanded).containsKey("@graph")
+        if (expanded instanceof Map && ((Map) expanded).containsKey(JsonLdConsts.GRAPH)
                 && ((Map) expanded).size() == 1) {
-            expanded = ((Map<String, Object>) expanded).get("@graph");
+            expanded = ((Map<String, Object>) expanded).get(JsonLdConsts.GRAPH);
         } else if (expanded == null) {
             expanded = new ArrayList<Object>();
         }
@@ -182,8 +182,8 @@ public class JsonLdProcessor {
         // 2-6) NOTE: these are all the same steps as in expand
         final Object expanded = expand(input, opts);
         // 7)
-        if (context instanceof Map && ((Map<String, Object>) context).containsKey("@context")) {
-            context = ((Map<String, Object>) context).get("@context");
+        if (context instanceof Map && ((Map<String, Object>) context).containsKey(JsonLdConsts.CONTEXT)) {
+            context = ((Map<String, Object>) context).get(JsonLdConsts.CONTEXT);
         }
         // 8) NOTE: blank node generation variables are members of JsonLdApi
         // 9) NOTE: the next block is the Flattening Algorithm described in
@@ -191,11 +191,11 @@ public class JsonLdProcessor {
 
         // 1)
         final Map<String, Object> nodeMap = newMap();
-        nodeMap.put("@default", newMap());
+        nodeMap.put(JsonLdConsts.DEFAULT, newMap());
         // 2)
         new JsonLdApi(opts).generateNodeMap(expanded, nodeMap);
         // 3)
-        final Map<String, Object> defaultGraph = (Map<String, Object>) nodeMap.remove("@default");
+        final Map<String, Object> defaultGraph = (Map<String, Object>) nodeMap.remove(JsonLdConsts.DEFAULT);
         // 4)
         for (final String graphName : nodeMap.keySet()) {
             final Map<String, Object> graph = (Map<String, Object>) nodeMap.get(graphName);
@@ -203,7 +203,7 @@ public class JsonLdProcessor {
             Map<String, Object> entry;
             if (!defaultGraph.containsKey(graphName)) {
                 entry = newMap();
-                entry.put("@id", graphName);
+                entry.put(JsonLdConsts.ID, graphName);
                 defaultGraph.put(graphName, entry);
             } else {
                 entry = (Map<String, Object>) defaultGraph.get(graphName);
@@ -211,15 +211,15 @@ public class JsonLdProcessor {
             // 4.3)
             // TODO: SPEC doesn't specify that this should only be added if it
             // doesn't exists
-            if (!entry.containsKey("@graph")) {
-                entry.put("@graph", new ArrayList<Object>());
+            if (!entry.containsKey(JsonLdConsts.GRAPH)) {
+                entry.put(JsonLdConsts.GRAPH, new ArrayList<Object>());
             }
             final List<String> keys = new ArrayList<String>(graph.keySet());
             Collections.sort(keys);
             for (final String id : keys) {
                 final Map<String, Object> node = (Map<String, Object>) graph.get(id);
-                if (!(node.containsKey("@id") && node.size() == 1)) {
-                    ((List<Object>) entry.get("@graph")).add(node);
+                if (!(node.containsKey(JsonLdConsts.ID) && node.size() == 1)) {
+                    ((List<Object>) entry.get(JsonLdConsts.GRAPH)).add(node);
                 }
             }
 
@@ -231,7 +231,7 @@ public class JsonLdProcessor {
         Collections.sort(keys);
         for (final String id : keys) {
             final Map<String, Object> node = (Map<String, Object>) defaultGraph.get(id);
-            if (!(node.containsKey("@id") && node.size() == 1)) {
+            if (!(node.containsKey(JsonLdConsts.ID) && node.size() == 1)) {
                 flattened.add(node);
             }
         }
@@ -247,7 +247,7 @@ public class JsonLdProcessor {
                 tmp.add(compacted);
                 compacted = tmp;
             }
-            final String alias = activeCtx.compactIri("@graph");
+            final String alias = activeCtx.compactIri(JsonLdConsts.GRAPH);
             final Map<String, Object> rval = activeCtx.serialize();
             rval.put(alias, compacted);
             return rval;
@@ -304,7 +304,7 @@ public class JsonLdProcessor {
 
         final JsonLdApi api = new JsonLdApi(expandedInput, opts);
         final List<Object> framed = api.frame(expandedInput, expandedFrame);
-        final Context activeCtx = api.context.parse(((Map<String, Object>) frame).get("@context"));
+        final Context activeCtx = api.context.parse(((Map<String, Object>) frame).get(JsonLdConsts.CONTEXT));
 
         Object compacted = api.compact(activeCtx, null, framed);
         if (!(compacted instanceof List)) {
@@ -312,7 +312,7 @@ public class JsonLdProcessor {
             tmp.add(compacted);
             compacted = tmp;
         }
-        final String alias = activeCtx.compactIri("@graph");
+        final String alias = activeCtx.compactIri(JsonLdConsts.GRAPH);
         final Map<String, Object> rval = activeCtx.serialize();
         rval.put(alias, compacted);
         JsonLdUtils.removePreserve(activeCtx, rval, opts);
@@ -328,8 +328,8 @@ public class JsonLdProcessor {
     private static Map<String, RDFParser> rdfParsers = new LinkedHashMap<String, RDFParser>() {
         {
             // automatically register nquad serializer
-            put("application/nquads", new NQuadRDFParser());
-            put("text/turtle", new TurtleRDFParser());
+            put(JsonLdConsts.APPLICATION_NQUADS, new NQuadRDFParser());
+            put(JsonLdConsts.TEXT_TURTLE, new TurtleRDFParser());
         }
     };
 
@@ -365,7 +365,7 @@ public class JsonLdProcessor {
 
         if (options.format == null && dataset instanceof String) {
             // attempt to parse the input as nquads
-            options.format = "application/nquads";
+            options.format = JsonLdConsts.APPLICATION_NQUADS;
         }
 
         if (rdfParsers.containsKey(options.format)) {
@@ -424,11 +424,11 @@ public class JsonLdProcessor {
 
         // re-process using the generated context if outputForm is set
         if (options.outputForm != null) {
-            if ("expanded".equals(options.outputForm)) {
+            if (JsonLdConsts.EXPANDED.equals(options.outputForm)) {
                 return rval;
-            } else if ("compacted".equals(options.outputForm)) {
+            } else if (JsonLdConsts.COMPACTED.equals(options.outputForm)) {
                 return compact(rval, dataset.getContext(), options);
-            } else if ("flattened".equals(options.outputForm)) {
+            } else if (JsonLdConsts.FLATTENED.equals(options.outputForm)) {
                 return flatten(rval, dataset.getContext(), options);
             } else {
                 throw new JsonLdError(JsonLdError.Error.UNKNOWN_ERROR, "Output form was unknown: "
@@ -494,8 +494,8 @@ public class JsonLdProcessor {
                 _input.add((Map<String, Object>) input);
             }
             for (final Map<String, Object> e : _input) {
-                if (e.containsKey("@context")) {
-                    dataset.parseContext(e.get("@context"));
+                if (e.containsKey(JsonLdConsts.CONTEXT)) {
+                    dataset.parseContext(e.get(JsonLdConsts.CONTEXT));
                 }
             }
         }
@@ -505,9 +505,9 @@ public class JsonLdProcessor {
         }
 
         if (options.format != null) {
-            if ("application/nquads".equals(options.format)) {
+            if (JsonLdConsts.APPLICATION_NQUADS.equals(options.format)) {
                 return new NQuadTripleCallback().call(dataset);
-            } else if ("text/turtle".equals(options.format)) {
+            } else if (JsonLdConsts.TEXT_TURTLE.equals(options.format)) {
                 return new TurtleTripleCallback().call(dataset);
             } else {
                 throw new JsonLdError(JsonLdError.Error.UNKNOWN_FORMAT, options.format);

--- a/core/src/test/java/com/github/jsonldjava/core/LocalBaseTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/LocalBaseTest.java
@@ -1,0 +1,61 @@
+package com.github.jsonldjava.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+
+import com.github.jsonldjava.utils.JsonUtils;
+
+public class LocalBaseTest {
+    @Test
+    public void testMixedLocalRemoteBaseRemoteContextFirst() throws Exception {
+
+        final Reader reader = new BufferedReader(new InputStreamReader(
+                this.getClass().getResourceAsStream("/custom/base-0001-in.jsonld"),
+                Charset.forName("UTF-8")));
+        final Object context = JsonUtils.fromReader(reader);
+        assertNotNull(context);
+
+        final JsonLdOptions options = new JsonLdOptions();
+        final Object expanded = JsonLdProcessor.expand(context, options);
+        System.out.println(JsonUtils.toPrettyString(expanded));
+
+        final Reader outReader = new BufferedReader(new InputStreamReader(
+                this.getClass().getResourceAsStream("/custom/base-0001-out.jsonld"),
+                Charset.forName("UTF-8")));
+        final Object output = JsonUtils.fromReader(outReader);
+        assertNotNull(output);
+        assertEquals(expanded, output);
+    }
+
+    @Test
+    public void testMixedLocalRemoteBaseLocalContextFirst() throws Exception {
+
+        final Reader reader = new BufferedReader(new InputStreamReader(
+                this.getClass().getResourceAsStream("/custom/base-0002-in.jsonld"),
+                Charset.forName("UTF-8")));
+        final Object context = JsonUtils.fromReader(reader);
+        assertNotNull(context);
+
+        final JsonLdOptions options = new JsonLdOptions();
+        final Object expanded = JsonLdProcessor.expand(context, options);
+        System.out.println(JsonUtils.toPrettyString(expanded));
+
+        final Reader outReader = new BufferedReader(new InputStreamReader(
+                this.getClass().getResourceAsStream("/custom/base-0002-out.jsonld"),
+                Charset.forName("UTF-8")));
+        final Object output = JsonUtils.fromReader(outReader);
+        assertNotNull(output);
+        assertEquals(expanded, output);
+    }
+
+}

--- a/core/src/test/resources/custom/base-0001-in.jsonld
+++ b/core/src/test/resources/custom/base-0001-in.jsonld
@@ -1,0 +1,16 @@
+{
+    "@context": [ 
+"https://raw.githubusercontent.com/monarch-initiative/monarch-app/master/conf/monarch-context.jsonld",
+        {
+            "@base": "http://example.org/base/",
+            "ex": "http://example.org/",
+            "ex:friendOf": {
+                "@type": "@id"
+            }
+        }
+    ],
+    "@id": "3456",
+    "ex:name": "Jim",
+    "ex:friendOf": "1234",
+    "@type": "Person"
+}

--- a/core/src/test/resources/custom/base-0001-out.jsonld
+++ b/core/src/test/resources/custom/base-0001-out.jsonld
@@ -1,0 +1,10 @@
+[ {
+  "@id" : "http://example.org/base/3456",
+  "@type" : [ "http://example.org/base/Person" ],
+  "http://example.org/friendOf" : [ {
+    "@id" : "http://example.org/base/1234"
+  } ],
+  "http://example.org/name" : [ {
+    "@value" : "Jim"
+  } ]
+} ]

--- a/core/src/test/resources/custom/base-0002-in.jsonld
+++ b/core/src/test/resources/custom/base-0002-in.jsonld
@@ -1,0 +1,16 @@
+{
+    "@context": [ 
+        {
+            "@base": "http://example.org/base/",
+            "ex": "http://example.org/",
+            "ex:friendOf": {
+                "@type": "@id"
+            }
+        },
+		"https://raw.githubusercontent.com/monarch-initiative/monarch-app/master/conf/monarch-context.jsonld"
+    ],
+    "@id": "3456",
+    "ex:name": "Jim",
+    "ex:friendOf": "1234",
+    "@type": "Person"
+}

--- a/core/src/test/resources/custom/base-0002-out.jsonld
+++ b/core/src/test/resources/custom/base-0002-out.jsonld
@@ -1,0 +1,10 @@
+[ {
+  "@id" : "http://example.org/base/3456",
+  "@type" : [ "http://example.org/base/Person" ],
+  "http://example.org/friendOf" : [ {
+    "@id" : "http://example.org/base/1234"
+  } ],
+  "http://example.org/name" : [ {
+    "@value" : "Jim"
+  } ]
+} ]


### PR DESCRIPTION
The JSONLD-API Context Processing Algorithm is specified as a recursive algorithm, but it doesn't seem to take into account that remote contexts must be operated on differently to the local context when they are mixed together. In particular, remote contexts must not propagate @base declarations out to the final context, although almost all of the rest of the context is propagated out otherwise.

This issue adds two regression tests, one with local context first, and the other with remote context first that demonstrate the issue. The regression test with local context first worked before the fix, but the remote context first was corrupting the final context by propagating an empty @base declaration out for some reason.

Fix for the issue is to introduce an inner private recursion method and a new boolean parameter on that method and use it to define what recursion stage we are at to know if we propagate @base out to the final context or not.