### PR TITLE
Literal compare was broken

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/RDFDataset.java
+++ b/core/src/main/java/com/github/jsonldjava/core/RDFDataset.java
@@ -297,17 +297,15 @@ public class RDFDataset extends LinkedHashMap<String, Object> {
                 // null, different type or different value 
                 return nodeCompare;
             }
-            
-            int langCompare = nullSafeCompare(this.getLanguage(), o.getLanguage());
-            if (langCompare != 0) {
-                return langCompare;
-            }
-            int dataTypeCompare = nullSafeCompare(this.getDatatype(), o.getDatatype());
-            if (dataTypeCompare != 0) {
-                return dataTypeCompare;
+            if (this.getLanguage() != null || o.getLanguage() != null) {
+                // We'll ignore type-checking if either has language tag
+                // as language tagged literals should always have the type
+                // rdf:langString in RDF 1.1
+                return nullSafeCompare(this.getLanguage(), o.getLanguage());
+            } else {
+                return nullSafeCompare(this.getDatatype(), o.getDatatype());
             }
             // NOTE: getValue() already compared by super.compareTo()
-            return 0;
         }
     }
 

--- a/core/src/main/java/com/github/jsonldjava/core/RDFDataset.java
+++ b/core/src/main/java/com/github/jsonldjava/core/RDFDataset.java
@@ -291,7 +291,7 @@ public class RDFDataset extends LinkedHashMap<String, Object> {
 
         @Override
         public int compareTo(Node o) {
-            // NOTE: this will also compare getValue()!
+            // NOTE: this will also compare getValue() early!
             int nodeCompare = super.compareTo(o);
             if (nodeCompare != 0) {
                 // null, different type or different value 
@@ -306,7 +306,7 @@ public class RDFDataset extends LinkedHashMap<String, Object> {
             if (dataTypeCompare != 0) {
                 return dataTypeCompare;
             }
-            // NOTE: getValue() has already compared by super.compareTo()
+            // NOTE: getValue() already compared by super.compareTo()
             return 0;
         }
     }

--- a/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
@@ -1,0 +1,140 @@
+package com.github.jsonldjava.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.github.jsonldjava.core.RDFDataset.Literal;
+import com.github.jsonldjava.core.RDFDataset.Node;
+import com.github.jsonldjava.core.RDFDataset.Quad;
+
+public class NodeCompareTest {
+
+    @Test
+    public void literalSameValue() throws Exception {
+        Literal l1 = new RDFDataset.Literal("Same", null, null);
+        Literal l2 = new RDFDataset.Literal("Same", null, null);
+        assertEquals(l1, l2);
+        assertEquals(0, l1.compareTo(l2));
+    }
+
+    @Test
+    public void literalDifferentValue() throws Exception {
+        Literal l1 = new RDFDataset.Literal("Same", null, null);
+        Literal l2 = new RDFDataset.Literal("Different", null, null);
+        assertNotEquals(l1, l2);
+        assertNotEquals(0, l1.compareTo(l2));
+    }
+
+    @Test
+    public void literalSameValuSameLang() throws Exception {
+        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        assertEquals(l1, l2);
+        assertEquals(0, l1.compareTo(l2));
+    }
+    
+    @Test
+    public void literalDifferentValueSameLang() throws Exception {
+        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new RDFDataset.Literal("Different", JsonLdConsts.RDF_LANGSTRING, "en");
+        assertNotEquals(l1, l2);
+        assertNotEquals(0, l1.compareTo(l2));
+    }
+
+    @Test
+    public void literalSameValueDifferentLang() throws Exception {
+        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "no");
+        assertNotEquals(l1, l2);
+        assertNotEquals(0, l1.compareTo(l2));
+    }    
+    
+    @Test
+    public void literalSameValueSameType() throws Exception {
+        Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
+        Literal l2 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
+        assertEquals(l1, l2);
+        assertEquals(0, l1.compareTo(l2));
+    }
+
+    @Test
+    public void literalSameValueDifferentType() throws Exception {
+        Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
+        Literal l2 = new RDFDataset.Literal("1", JsonLdConsts.XSD_STRING, null);
+        assertNotEquals(l1, l2);
+        assertNotEquals(0, l1.compareTo(l2));
+    }
+    
+
+    
+    @Test
+    public void literalsInDataset() throws Exception {
+        RDFDataset dataset = new RDFDataset();
+        dataset.addQuad("http://example.com/p", "http://example.com/p", "Same", null, null, "http://example.com/g1");
+        dataset.addQuad("http://example.com/p", "http://example.com/p", "Different", null, null, "http://example.com/g1");
+        List<Quad> quads = dataset.getQuads("http://example.com/g1");
+        Quad q1 = quads.get(0);
+        Quad q2 = quads.get(1);
+        assertNotEquals(q1, q2);
+        assertNotEquals(0, q1.compareTo(q2));
+        assertNotEquals(0, q1.getObject().compareTo(q2.getObject()));
+    }
+
+    @Test
+    public void iriDifferentLiteral() throws Exception {
+        Node iri = new RDFDataset.IRI("http://example.com/");
+        Node literal = new RDFDataset.Literal("http://example.com/", null, null);
+        assertNotEquals(iri, literal);
+        assertNotEquals(0, iri.compareTo(literal));
+    }
+
+    @Test
+    public void iriDifferentIri() throws Exception {
+        Node iri = new RDFDataset.IRI("http://example.com/");
+        Node other = new RDFDataset.IRI("http://example.com/other");
+        assertNotEquals(iri, other);
+        assertNotEquals(0, iri.compareTo(other));
+    }
+    
+    @Test
+    public void iriSameIri() throws Exception {
+        Node iri = new RDFDataset.IRI("http://example.com/same");
+        Node same = new RDFDataset.IRI("http://example.com/same");
+        assertEquals(iri, same);
+        assertEquals(0, iri.compareTo(same));
+    }
+        
+    @Test
+    public void iriDifferentBlankNode() throws Exception {
+        // We'll use a relative IRI to avoid :-issues
+        Node iri = new RDFDataset.IRI("b1");
+        Node bnode = new RDFDataset.BlankNode("b1");
+        assertNotEquals(iri, bnode);
+        assertNotEquals(0, iri.compareTo(bnode));
+    }
+
+    @Test
+    public void literalDifferentIri() throws Exception {
+        Node literal = new RDFDataset.Literal("http://example.com/", null, null);
+        Node iri = new RDFDataset.IRI("http://example.com/");
+        assertNotEquals(literal, iri);
+        assertNotEquals(0, literal.compareTo(iri));
+    }
+    
+    @Test
+    public void literalDifferentBlankNode() throws Exception {
+        // We'll use a relative IRI to avoid :-issues
+        Node literal = new RDFDataset.Literal("b1", null, null);
+        Node bnode = new RDFDataset.BlankNode("b1");
+        assertNotEquals(literal, bnode);
+        assertNotEquals(0, literal.compareTo(bnode));
+    }
+
+
+    
+    
+}

--- a/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
@@ -1,62 +1,122 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import org.junit.Test;
 
+import com.github.jsonldjava.core.RDFDataset.IRI;
+import com.github.jsonldjava.core.RDFDataset.BlankNode;
 import com.github.jsonldjava.core.RDFDataset.Literal;
 import com.github.jsonldjava.core.RDFDataset.Node;
 import com.github.jsonldjava.core.RDFDataset.Quad;
 
+import junit.framework.Assert;
+
 public class NodeCompareTest {
 
     @Test
+    public void ordered() throws Exception {
+        List<Node> expected = Arrays.asList(
+                // While this order might not particularly make sense, it
+                // is at least documented
+                
+                new Literal("1", JsonLdConsts.XSD_INTEGER, null),
+                new Literal("10", JsonLdConsts.XSD_INTEGER, null),
+                new Literal("2", JsonLdConsts.XSD_INTEGER, null), // still ordered by string value
+                
+                new Literal("a", JsonLdConsts.RDF_LANGSTRING, "en"), 
+                new Literal("a", JsonLdConsts.RDF_LANGSTRING, "fr"), 
+                new Literal("a", null, null), // equivalent to xsd:string
+                new Literal("b", JsonLdConsts.XSD_STRING, null),
+                new Literal("false", JsonLdConsts.XSD_BOOLEAN, null),
+                new Literal("true", JsonLdConsts.XSD_BOOLEAN, null),
+
+                new Literal("x", JsonLdConsts.XSD_STRING, null),
+
+                new Literal("z", JsonLdConsts.RDF_LANGSTRING, "en"),
+                new Literal("z", JsonLdConsts.RDF_LANGSTRING, "fr"),                
+                new Literal("z", null, null),
+
+                new BlankNode("a"),
+                new BlankNode("f"),
+                new BlankNode("z"),
+
+                new IRI("http://example.com/ex1"),
+                new IRI("http://example.com/ex2"),
+                new IRI("http://example.org/ex"),
+                new IRI("https://example.net/")
+        );
+        
+        List<Node> shuffled = new ArrayList<>(expected);
+        Random rand = new Random(1337); // fixed seed
+        Collections.shuffle(shuffled, rand);
+        //System.out.println("Shuffled:");
+        //shuffled.stream().forEach(System.out::println);
+        assertNotEquals(expected, shuffled);
+
+        Collections.sort(shuffled);
+        List<Node> sorted = shuffled;
+        //System.out.println("Now sorted:");
+        //sorted.stream().forEach(System.out::println);
+        // Not so useful output from this
+        //        assertEquals(expected, sorted);
+        // so we'll instead do:
+        for (int i=0; i<expected.size(); i++) {
+            assertEquals("Wrong sort order at position " + i, 
+                    expected.get(i), sorted.get(i));
+        }
+    }
+    
+    @Test
     public void literalSameValue() throws Exception {
-        Literal l1 = new RDFDataset.Literal("Same", null, null);
-        Literal l2 = new RDFDataset.Literal("Same", null, null);
+        Literal l1 = new Literal("Same", null, null);
+        Literal l2 = new Literal("Same", null, null);
         assertEquals(l1, l2);
         assertEquals(0, l1.compareTo(l2));
     }
 
     @Test
     public void literalDifferentValue() throws Exception {
-        Literal l1 = new RDFDataset.Literal("Same", null, null);
-        Literal l2 = new RDFDataset.Literal("Different", null, null);
+        Literal l1 = new Literal("Same", null, null);
+        Literal l2 = new Literal("Different", null, null);
         assertNotEquals(l1, l2);
         assertNotEquals(0, l1.compareTo(l2));
     }
 
     @Test
     public void literalSameValueSameLang() throws Exception {
-        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
-        Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l1 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
         assertEquals(l1, l2);
         assertEquals(0, l1.compareTo(l2));
     }
     
     @Test
     public void literalDifferentValueSameLang() throws Exception {
-        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
-        Literal l2 = new RDFDataset.Literal("Different", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l1 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new Literal("Different", JsonLdConsts.RDF_LANGSTRING, "en");
         assertNotEquals(l1, l2);
         assertNotEquals(0, l1.compareTo(l2));
     }
 
     @Test
     public void literalSameValueDifferentLang() throws Exception {
-        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
-        Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "no");
+        Literal l1 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, "no");
         assertNotEquals(l1, l2);
         assertNotEquals(0, l1.compareTo(l2));
     }    
 
     @Test
     public void literalSameValueLangNull() throws Exception {
-        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
-        Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, null);
+        Literal l1 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new Literal("Same", JsonLdConsts.RDF_LANGSTRING, null);
         assertNotEquals(l1, l2);
         assertNotEquals(0, l1.compareTo(l2));
         assertNotEquals(0, l2.compareTo(l1));
@@ -65,16 +125,16 @@ public class NodeCompareTest {
     
     @Test
     public void literalSameValueSameType() throws Exception {
-        Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
-        Literal l2 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
+        Literal l1 = new Literal("1", JsonLdConsts.XSD_INTEGER, null);
+        Literal l2 = new Literal("1", JsonLdConsts.XSD_INTEGER, null);
         assertEquals(l1, l2);
         assertEquals(0, l1.compareTo(l2));
     }
 
     @Test
     public void literalSameValueSameTypeNull() throws Exception {
-        Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_STRING, null);
-        Literal l2 = new RDFDataset.Literal("1", null, null);
+        Literal l1 = new Literal("1", JsonLdConsts.XSD_STRING, null);
+        Literal l2 = new Literal("1", null, null);
         assertEquals(l1, l2);
         assertEquals(0, l1.compareTo(l2));
     }
@@ -82,8 +142,8 @@ public class NodeCompareTest {
     
     @Test
     public void literalSameValueDifferentType() throws Exception {
-        Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
-        Literal l2 = new RDFDataset.Literal("1", JsonLdConsts.XSD_STRING, null);
+        Literal l1 = new Literal("1", JsonLdConsts.XSD_INTEGER, null);
+        Literal l2 = new Literal("1", JsonLdConsts.XSD_STRING, null);
         assertNotEquals(l1, l2);
         assertNotEquals(0, l1.compareTo(l2));
     }
@@ -105,8 +165,8 @@ public class NodeCompareTest {
 
     @Test
     public void iriDifferentLiteral() throws Exception {
-        Node iri = new RDFDataset.IRI("http://example.com/");
-        Node literal = new RDFDataset.Literal("http://example.com/", null, null);
+        Node iri = new IRI("http://example.com/");
+        Node literal = new Literal("http://example.com/", null, null);
         assertNotEquals(iri, literal);
         assertNotEquals(0, iri.compareTo(literal));
         assertNotEquals(0, literal.compareTo(iri));
@@ -114,28 +174,28 @@ public class NodeCompareTest {
 
     @Test
     public void iriDifferentNull() throws Exception {
-        Node iri = new RDFDataset.IRI("http://example.com/");
+        Node iri = new IRI("http://example.com/");
         assertNotEquals(0, iri.compareTo(null));
     }
 
     @Test
     public void literalDifferentNull() throws Exception {
-        Node literal = new RDFDataset.Literal("hello", null, null);
+        Node literal = new Literal("hello", null, null);
         assertNotEquals(0, literal.compareTo(null));
     }    
     
     @Test
     public void iriDifferentIri() throws Exception {
-        Node iri = new RDFDataset.IRI("http://example.com/");
-        Node other = new RDFDataset.IRI("http://example.com/other");
+        Node iri = new IRI("http://example.com/");
+        Node other = new IRI("http://example.com/other");
         assertNotEquals(iri, other);
         assertNotEquals(0, iri.compareTo(other));
     }
     
     @Test
     public void iriSameIri() throws Exception {
-        Node iri = new RDFDataset.IRI("http://example.com/same");
-        Node same = new RDFDataset.IRI("http://example.com/same");
+        Node iri = new IRI("http://example.com/same");
+        Node same = new IRI("http://example.com/same");
         assertEquals(iri, same);
         assertEquals(0, iri.compareTo(same));
     }
@@ -143,8 +203,8 @@ public class NodeCompareTest {
     @Test
     public void iriDifferentBlankNode() throws Exception {
         // We'll use a relative IRI to avoid :-issues
-        Node iri = new RDFDataset.IRI("b1");
-        Node bnode = new RDFDataset.BlankNode("b1");
+        Node iri = new IRI("b1");
+        Node bnode = new BlankNode("b1");
         assertNotEquals(iri, bnode);
         assertNotEquals(bnode, iri);
         assertNotEquals(0, iri.compareTo(bnode));
@@ -154,8 +214,8 @@ public class NodeCompareTest {
     @Test
     public void literalDifferentBlankNode() throws Exception {
         // We'll use a relative IRI to avoid :-issues
-        Node literal = new RDFDataset.Literal("b1", null, null);
-        Node bnode = new RDFDataset.BlankNode("b1");
+        Node literal = new Literal("b1", null, null);
+        Node bnode = new BlankNode("b1");
         assertNotEquals(literal, bnode);
         assertNotEquals(bnode, literal);
         assertNotEquals(0, literal.compareTo(bnode));

--- a/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
@@ -1,6 +1,7 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,22 +11,23 @@ import java.util.Random;
 
 import org.junit.Test;
 
-import com.github.jsonldjava.core.RDFDataset.IRI;
 import com.github.jsonldjava.core.RDFDataset.BlankNode;
+import com.github.jsonldjava.core.RDFDataset.IRI;
 import com.github.jsonldjava.core.RDFDataset.Literal;
 import com.github.jsonldjava.core.RDFDataset.Node;
 import com.github.jsonldjava.core.RDFDataset.Quad;
 
-import junit.framework.Assert;
-
 public class NodeCompareTest {
 
+    /**
+     * While this order might not particularly make sense (RDF is unordered),
+     * this is at least documented. Feel free to move things around below if the
+     * underlying .compareTo() changes.
+     */
     @Test
     public void ordered() throws Exception {
         List<Node> expected = Arrays.asList(
-                // While this order might not particularly make sense, it
-                // is at least documented
-                
+
                 new Literal("1", JsonLdConsts.XSD_INTEGER, null),
                 new Literal("10", JsonLdConsts.XSD_INTEGER, null),
                 new Literal("2", JsonLdConsts.XSD_INTEGER, null), // still ordered by string value

--- a/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
@@ -30,7 +30,7 @@ public class NodeCompareTest {
     }
 
     @Test
-    public void literalSameValuSameLang() throws Exception {
+    public void literalSameValueSameLang() throws Exception {
         Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
         Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
         assertEquals(l1, l2);
@@ -52,6 +52,16 @@ public class NodeCompareTest {
         assertNotEquals(l1, l2);
         assertNotEquals(0, l1.compareTo(l2));
     }    
+
+    @Test
+    public void literalSameValueLangNull() throws Exception {
+        Literal l1 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, "en");
+        Literal l2 = new RDFDataset.Literal("Same", JsonLdConsts.RDF_LANGSTRING, null);
+        assertNotEquals(l1, l2);
+        assertNotEquals(0, l1.compareTo(l2));
+        assertNotEquals(0, l2.compareTo(l1));
+    }    
+    
     
     @Test
     public void literalSameValueSameType() throws Exception {
@@ -61,6 +71,15 @@ public class NodeCompareTest {
         assertEquals(0, l1.compareTo(l2));
     }
 
+    @Test
+    public void literalSameValueSameTypeNull() throws Exception {
+        Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_STRING, null);
+        Literal l2 = new RDFDataset.Literal("1", null, null);
+        assertEquals(l1, l2);
+        assertEquals(0, l1.compareTo(l2));
+    }
+
+    
     @Test
     public void literalSameValueDifferentType() throws Exception {
         Literal l1 = new RDFDataset.Literal("1", JsonLdConsts.XSD_INTEGER, null);
@@ -90,8 +109,21 @@ public class NodeCompareTest {
         Node literal = new RDFDataset.Literal("http://example.com/", null, null);
         assertNotEquals(iri, literal);
         assertNotEquals(0, iri.compareTo(literal));
+        assertNotEquals(0, literal.compareTo(iri));
     }
 
+    @Test
+    public void iriDifferentNull() throws Exception {
+        Node iri = new RDFDataset.IRI("http://example.com/");
+        assertNotEquals(0, iri.compareTo(null));
+    }
+
+    @Test
+    public void literalDifferentNull() throws Exception {
+        Node literal = new RDFDataset.Literal("hello", null, null);
+        assertNotEquals(0, literal.compareTo(null));
+    }    
+    
     @Test
     public void iriDifferentIri() throws Exception {
         Node iri = new RDFDataset.IRI("http://example.com/");
@@ -114,27 +146,22 @@ public class NodeCompareTest {
         Node iri = new RDFDataset.IRI("b1");
         Node bnode = new RDFDataset.BlankNode("b1");
         assertNotEquals(iri, bnode);
+        assertNotEquals(bnode, iri);
         assertNotEquals(0, iri.compareTo(bnode));
+        assertNotEquals(0, bnode.compareTo(iri));
     }
 
-    @Test
-    public void literalDifferentIri() throws Exception {
-        Node literal = new RDFDataset.Literal("http://example.com/", null, null);
-        Node iri = new RDFDataset.IRI("http://example.com/");
-        assertNotEquals(literal, iri);
-        assertNotEquals(0, literal.compareTo(iri));
-    }
-    
     @Test
     public void literalDifferentBlankNode() throws Exception {
         // We'll use a relative IRI to avoid :-issues
         Node literal = new RDFDataset.Literal("b1", null, null);
         Node bnode = new RDFDataset.BlankNode("b1");
         assertNotEquals(literal, bnode);
+        assertNotEquals(bnode, literal);
         assertNotEquals(0, literal.compareTo(bnode));
+        assertNotEquals(0, bnode.compareTo(literal));
+
     }
-
-
     
     
 }

--- a/core/src/test/java/com/github/jsonldjava/core/QuadCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/QuadCompareTest.java
@@ -1,0 +1,66 @@
+package com.github.jsonldjava.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+import com.github.jsonldjava.core.RDFDataset.Quad;
+
+public class QuadCompareTest {
+
+    Quad q = new Quad("http://example.com/s1", "http://example.com/p1", 
+            "http://example.com/o1", "http://example.com/g1");
+    
+    @Test
+    public void compareToNull() throws Exception {
+        assertNotEquals(0, q.compareTo(null));
+    }
+    
+    @Test
+    public void compareToSame() throws Exception {
+        Quad q2 = new Quad("http://example.com/s1", "http://example.com/p1", 
+            "http://example.com/o1", "http://example.com/g1");
+        assertEquals(0, q.compareTo(q2));
+        // Should still compare equal, even if extra attributes are added
+        q2.put("example", "value");
+        assertEquals(0, q.compareTo(q2));
+    }
+    
+    @Test
+    public void compareToDifferentGraph() throws Exception {
+        Quad q2 = new Quad("http://example.com/s1", "http://example.com/p1", 
+            "http://example.com/o1", "http://example.com/other");
+        assertNotEquals(0, q.compareTo(q2));
+    }
+
+    @Test
+    public void compareToDifferentSubject() throws Exception {
+        Quad q2 = new Quad("http://example.com/other", "http://example.com/p1", 
+            "http://example.com/o1", "http://example.com/g1");
+        assertNotEquals(0, q.compareTo(q2));
+    }
+
+    @Test
+    public void compareToDifferentPredicate() throws Exception {
+        Quad q2 = new Quad("http://example.com/s1", "http://example.com/other", 
+            "http://example.com/o1", "http://example.com/g1");
+        assertNotEquals(0, q.compareTo(q2));
+    }
+
+    @Test
+    public void compareToDifferentObject() throws Exception {
+        Quad q2 = new Quad("http://example.com/s1", "http://example.com/p1", 
+            "http://example.com/other", "http://example.com/g1");
+        assertNotEquals(0, q.compareTo(q2));
+    }
+
+    @Test
+    public void compareToDifferentObjectType() throws Exception {
+        Quad q2 = new Quad("http://example.com/s1", "http://example.com/p1", 
+            "http://example.com/other", null, null, // literal
+            "http://example.com/g1");
+        assertNotEquals(0, q.compareTo(q2));
+    }
+
+}


### PR DESCRIPTION
The Node.compareTo() of `RDFDataset.Literal` was broken in that it didn't compare the `.getValue()`, also it didn't compare `.getLanguage()` or `.getDataType()`, assuming they were equal as long as both were null.

This broke Commons RDF which assumed Nodes could be compared for their value, which was only true for `IRI` and `BlankNode`.

This PR adds unit tests for almost all the possible `Node` comparisons as well as fixing the problem in `Literal.compareTo()`.

I am not certain about keeping the datatype null-checks - as it means for instance a Literal with explicit XSD_STRING differs from one without. Also not sure if literals with language tags should even compare data types at all.