### PR TITLE
Added injected string-based context

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The default HTTP Client is wrapped with a
 small memory-based cache (1000 objects, max 128 kB each) of regularly accessed contexts.
 
 
-### Loading contexts from classpath/JAR
+### Loading contexts from classpath
 
 Your application might be parsing JSONLD documents which always use the same
 external `@context` IRIs. Although the default HTTP cache (see above) will
@@ -136,6 +136,30 @@ You can also use the constant provided in DocumentLoader for the same purpose:
     System.setProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING, "true");
 
 Note that if you override DocumentLoader you should also support this setting for consistency.
+
+
+### Loading contexts from a string
+
+Your application might be parsing JSONLD documents which reference external `@context` IRIs
+that are not available as file URIs on the classpath. In this case, the `jarcache.json`
+approch will not work. Instead you can inject the literal context file strings through
+the `JsonLdOptions` object, as follows:
+
+```java
+// Inject a context document into the options as a literal string
+DocumentLoader dl = new DocumentLoader();
+JsonLdOptions options = new JsonLdOptions();
+// ... the contents of "contexts/example.jsonld"
+String jsonContext = "{ \"@contxt\": { ... } }";
+dl.addInjectedDoc("http://www.example.com/context",  jsonContext);
+options.setDocumentLoader(dl);
+
+InputStream inputStream = new FileInputStream("input.json");
+Object jsonObject = JsonUtils.fromInputStream(inputStream);
+Map context = new HashMap();
+Object compact = JsonLdProcessor.compact(jsonObject, context, options);
+System.out.println(JsonUtils.toPrettyString(compact));
+```
 
 ### Customizing the Apache HttpClient
 

--- a/core/src/main/java/com/github/jsonldjava/core/DocumentLoader.java
+++ b/core/src/main/java/com/github/jsonldjava/core/DocumentLoader.java
@@ -1,6 +1,8 @@
 package com.github.jsonldjava.core;
 
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -8,21 +10,41 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 public class DocumentLoader {
 
+    private Map<String, Object> m_injectedDocs = new HashMap<>();
+
     /**
      * Identifies a system property that can be set to "true" in order to
      * disallow remote context loading.
      */
     public static final String DISALLOW_REMOTE_CONTEXT_LOADING = "com.github.jsonldjava.disallowRemoteContextLoading";
 
+    public DocumentLoader addInjectedDoc(String url, String doc) throws JsonLdError {
+        try {
+            m_injectedDocs.put(url, JsonUtils.fromString(doc));
+            return this;
+        } catch (final Exception e) {
+            throw new JsonLdError(JsonLdError.Error.LOADING_INJECTED_CONTEXT_FAILED, url, e);
+        }
+    }
+
     public RemoteDocument loadDocument(String url) throws JsonLdError {
+        final RemoteDocument doc = new RemoteDocument(url, null);
+
+        if (m_injectedDocs.containsKey(url)) {
+            try {
+                doc.setDocument(m_injectedDocs.get(url));
+            } catch (final Exception e) {
+                throw new JsonLdError(JsonLdError.Error.LOADING_INJECTED_CONTEXT_FAILED, url, e);
+            }
+            return doc;
+        }
+
         final String disallowRemote = System
                 .getProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING);
-
         if ("true".equalsIgnoreCase(disallowRemote)) {
             throw new JsonLdError(JsonLdError.Error.LOADING_REMOTE_CONTEXT_FAILED, "Remote context loading has been disallowed (url was " + url + ")");
         }
 
-        final RemoteDocument doc = new RemoteDocument(url, null);
         try {
             doc.setDocument(JsonUtils.fromURL(new URL(url), getHttpClient()));
         } catch (final Exception e) {

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdError.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdError.java
@@ -44,6 +44,8 @@ public class JsonLdError extends Exception {
 
         LOADING_REMOTE_CONTEXT_FAILED("loading remote context failed"),
 
+        LOADING_INJECTED_CONTEXT_FAILED("loading injected context failed"),
+
         INVALID_REMOTE_CONTEXT("invalid remote context"),
 
         RECURSIVE_CONTEXT_INCLUSION("recursive context inclusion"),


### PR DESCRIPTION
I added the ability to load context files from strings instead of through the "jarcache.json" function, as that depends upon files being available through "file://" URIs on the classpath (bad presumption). This also gets around the problem of conflicting "jarcache.json" instances when building reusable libraries.