### PR TITLE
Framing fixes

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdConsts.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdConsts.java
@@ -57,4 +57,6 @@ public final class JsonLdConsts {
     public static final String BLANK_NODE_PREFIX = "_:";
     public static final String VOCAB = "@vocab";
     public static final String BASE = "@base";
+
+    public enum Embed {	ALWAYS,	NEVER, LAST, LINK; }
 }

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdError.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdError.java
@@ -100,6 +100,8 @@ public class JsonLdError extends Exception {
 
         INVALID_REVERSE_PROPERTY_VALUE("invalid reverse property value"),
 
+        INVALID_EMBED_VALUE("invalid @embed value"),
+
         // non spec related errors
         SYNTAX_ERROR("syntax error"),
 

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
@@ -1,5 +1,7 @@
 package com.github.jsonldjava.core;
 
+import com.github.jsonldjava.core.JsonLdConsts.Embed;
+
 /**
  * The JsonLdOptions type as specified in the
  * <a href="http://www.w3.org/TR/json-ld-api/#the-jsonldoptions-type">JSON-LD-
@@ -59,7 +61,7 @@ public class JsonLdOptions {
 
     // Frame options : http://json-ld.org/spec/latest/json-ld-framing/
 
-    private Boolean embed = null;
+    private Embed embed = Embed.LAST;
     private Boolean explicit = null;
     private Boolean omitDefault = null;
     private Boolean pruneBlankNodeIdentifiers = true;
@@ -71,12 +73,40 @@ public class JsonLdOptions {
     Boolean useNativeTypes = false;
     private boolean produceGeneralizedRdf = false;
 
-    public Boolean getEmbed() {
-        return embed;
+    public String getEmbed() {
+        switch (this.embed) {
+        case ALWAYS:
+            return "@always";
+        case NEVER:
+            return "@never";
+        case LINK:
+            return "@link";
+        default:
+            return "@last";
+        }
+    }
+
+    Embed getEmbedVal() {
+        return this.embed;
     }
 
     public void setEmbed(Boolean embed) {
-        this.embed = embed;
+        this.embed = embed ? Embed.LAST : Embed.NEVER;
+    }
+
+    public void setEmbed(String embed) throws JsonLdError {
+        switch (embed) {
+        case "@always":
+            this.embed = Embed.ALWAYS;
+        case "@never":
+            this.embed = Embed.NEVER;
+        case "@last":
+            this.embed = Embed.LAST;
+        case "@link":
+            this.embed = Embed.LINK;
+        default:
+            throw new JsonLdError(JsonLdError.Error.INVALID_EMBED_VALUE);
+        }
     }
 
     public Boolean getExplicit() {

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
@@ -12,9 +12,11 @@ import com.github.jsonldjava.core.JsonLdConsts.Embed;
  */
 public class JsonLdOptions {
 
-    private static final String JSON_LD_1_0 = "json-ld-1.0";
+    public static final String JSON_LD_1_0 = "json-ld-1.0";
 
-    private static final String JSON_LD_1_1 = "json-ld-1.1";
+    public static final String JSON_LD_1_1 = "json-ld-1.1";
+    
+    public static final String JSON_LD_1_1_FRAME = "json-ld-1.1-expand-frame";
 
     public static final boolean DEFAULT_COMPACT_ARRAYS = true;
 

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
@@ -308,13 +308,25 @@ public class JsonLdProcessor {
         }
         // TODO string/IO input
 
+        // 2. Set expanded input to the result of using the expand method using input and options. 
         final Object expandedInput = expand(input, opts);
+        
+        // 3. Set expanded frame to the result of using the expand method using frame and options
+        // with expandContext set to null and processingMode set to json-ld-1.1-expand-frame. 
+        String savedProcessingMode = opts.getProcessingMode();
+        Object savedExpandedContext = opts.getExpandContext();
+        opts.setProcessingMode(JsonLdOptions.JSON_LD_1_1_FRAME);
+        opts.setExpandContext(null);
         final List<Object> expandedFrame = expand(frame, opts);
+        opts.setProcessingMode(savedProcessingMode);
+        opts.setExpandContext(savedExpandedContext);
 
+        // 4. Set context to the value of @context from frame, if it exists, or to a new empty
+        // context, otherwise.
         final JsonLdApi api = new JsonLdApi(expandedInput, opts);
-        final List<Object> framed = api.frame(expandedInput, expandedFrame);
         final Context activeCtx = api.context
                 .parse(((Map<String, Object>) frame).get(JsonLdConsts.CONTEXT));
+        final List<Object> framed = api.frame(expandedInput, expandedFrame);
 
         Object compacted = api.compact(activeCtx, null, framed, opts.getCompactArrays());
         if (!(compacted instanceof List)) {

--- a/core/src/test/resources/json-ld.org/frame-0030-frame.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-0030-frame.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "ex": "http://www.example.com/#"
+  },
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@embed": "@always"
+  },
+  "ex:noembed": {
+    "@embed": "@never"
+  }
+}

--- a/core/src/test/resources/json-ld.org/frame-0030-in.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-0030-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "ex": "http://www.example.com/#"
+  },
+  "@id": "ex:subject",
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@id": "ex:embedded",
+    "ex:title": "Embedded"
+  },
+  "ex:noembed": {
+    "@id": "ex:notembedded",
+    "ex:title": "Not Embedded"
+  }
+}

--- a/core/src/test/resources/json-ld.org/frame-0030-out.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-0030-out.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "ex": "http://www.example.com/#"
+  },
+  "@graph": [{
+    "@id": "ex:subject",
+    "@type": "ex:Thing",
+    "ex:embed": {
+      "@id": "ex:embedded",
+      "ex:title": "Embedded"
+    },
+    "ex:noembed": {
+      "@id": "ex:notembedded"
+    }
+  }]
+}

--- a/core/src/test/resources/json-ld.org/frame-manifest.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-manifest.jsonld
@@ -152,13 +152,19 @@
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
       "expect": "frame-0021-out.jsonld"
-    }
-    , {
-          "@id": "#t0022",
-          "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
-          "name": "Default inside sets",
-          "input": "frame-0022-in.jsonld",
-          "frame": "frame-0022-frame.jsonld",
-          "expect": "frame-0022-out.jsonld"
-        }]
+    } , {
+      "@id": "#t0022",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Default inside sets",
+      "input": "frame-0022-in.jsonld",
+      "frame": "frame-0022-frame.jsonld",
+      "expect": "frame-0022-out.jsonld"
+    } , {
+      "@id": "#t0030",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "@embed",
+      "input": "frame-0030-in.jsonld",
+      "frame": "frame-0030-frame.jsonld",
+      "expect": "frame-0030-out.jsonld"
+    }]
 }


### PR DESCRIPTION
- support new `@embed` values (backward compatible), avoid circular embedding
- support framing by `@id`
- fix a bug with `pruneBlankNodes` when a blank node was present 3 times
- comment the framing algorithm code