### PR TITLE
150 add test for embedding same data multiple times

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
@@ -101,12 +101,16 @@ public class JsonLdOptions {
         switch (embed) {
         case "@always":
             this.embed = Embed.ALWAYS;
+            break;
         case "@never":
             this.embed = Embed.NEVER;
+            break;
         case "@last":
             this.embed = Embed.LAST;
+            break;
         case "@link":
             this.embed = Embed.LINK;
+            break;
         default:
             throw new JsonLdError(JsonLdError.Error.INVALID_EMBED_VALUE);
         }

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
@@ -123,4 +123,21 @@ public class JsonLdFramingTest {
                 .fromInputStream(getClass().getResourceAsStream("/custom/frame-0007-out.jsonld"));
         assertEquals(out, frame2);
     }
+
+    @Test
+    public void testFrame0008() throws IOException, JsonLdError {
+        final Object frame = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0008-frame.jsonld"));
+        final Object in = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0008-in.jsonld"));
+
+        JsonLdOptions opts = new JsonLdOptions();
+        opts.setEmbed("@always");
+        final Map<String, Object> frame2 = JsonLdProcessor.frame(in, frame, opts);
+
+        final Object out = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0008-out.jsonld"));
+        assertEquals(out, frame2);
+    }
 }
+

--- a/core/src/test/resources/custom/frame-0008-frame.jsonld
+++ b/core/src/test/resources/custom/frame-0008-frame.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "dct": "http://purl.org/dc/terms/",
+    "ex": "http://example.org/vocab#"
+  },
+  "@type": "ex:Biography"
+}

--- a/core/src/test/resources/custom/frame-0008-in.jsonld
+++ b/core/src/test/resources/custom/frame-0008-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "dct": "http://purl.org/dc/terms/",
+    "ex": "http://example.org/vocab#"
+  },
+  "@graph": [
+    {
+      "@id": "http://lobid.org/resources/HT019277879",
+      "@type": "ex:Biography",
+      "dct:creator": {
+        "@id" : "https://www.wikidata.org/entity/Q115211",
+        "ex:name": "Harry Rowohlt"
+      },
+      "dct:subject": {
+        "@id" : "https://www.wikidata.org/entity/Q115211",
+        "ex:name": "Harry Rowohlt"
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/custom/frame-0008-out.jsonld
+++ b/core/src/test/resources/custom/frame-0008-out.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "dct": "http://purl.org/dc/terms/",
+    "ex": "http://example.org/vocab#"
+  },
+  "@graph": [
+    {
+      "@id": "http://lobid.org/resources/HT019277879",
+      "@type": "ex:Biography",
+      "dct:creator": {
+        "@id" : "https://www.wikidata.org/entity/Q115211",
+        "ex:name": "Harry Rowohlt"
+      },
+      "dct:subject": {
+        "@id" : "https://www.wikidata.org/entity/Q115211",
+        "ex:name": "Harry Rowohlt"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Provides a test for frames using `@embed:@always`.

This complements 4fe56fd and shows that #150
is indeed resolved.

Also fixes a "switch" fallthrough bug in JsonLdOptions.