### PR TITLE
issue #196 : Avoid calling ClassLoader.getResources multiple times

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
@@ -24,6 +24,7 @@ import org.apache.http.client.protocol.RequestAcceptEncoding;
 import org.apache.http.client.protocol.ResponseContentEncoding;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.cache.BasicHttpCacheStorage;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
@@ -410,13 +411,27 @@ public class JsonUtils {
         return result;
     }
 
-    private static CloseableHttpClient createDefaultHttpClient() {
+    public static CloseableHttpClient createDefaultHttpClient() {
+        final CacheConfig cacheConfig = createDefaultCacheConfig();
+
+        final CloseableHttpClient result = createDefaultHttpClient(cacheConfig);
+
+        return result;
+    }
+
+    public static CacheConfig createDefaultCacheConfig() {
+        return CacheConfig.custom().setMaxCacheEntries(500)
+                .setMaxObjectSize(1024 * 256).build();
+    }
+
+    public static CloseableHttpClient createDefaultHttpClient(final CacheConfig cacheConfig) {
+        return createDefaultHttpClientBuilder(cacheConfig).build();
+    }
+
+    public static HttpClientBuilder createDefaultHttpClientBuilder(final CacheConfig cacheConfig) {
         // Common CacheConfig for both the JarCacheStorage and the underlying
         // BasicHttpCacheStorage
-        final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(500)
-                .setMaxObjectSize(1024 * 256).build();
-
-        final CloseableHttpClient result = CachingHttpClientBuilder.create()
+        return CachingHttpClientBuilder.create()
                 // allow caching
                 .setCacheConfig(cacheConfig)
                 // Wrap the local JarCacheStorage around a BasicHttpCacheStorage
@@ -430,9 +445,7 @@ public class JsonUtils {
                 // User agent customisation
                 .setUserAgent(JSONLD_JAVA_USER_AGENT)
                 // use system defaults for proxy etc.
-                .useSystemProperties().build();
-
-        return result;
+                .useSystemProperties();
     }
 
     private JsonUtils() {

--- a/core/src/test/java/com/github/jsonldjava/core/DocumentLoaderTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/DocumentLoaderTest.java
@@ -304,6 +304,8 @@ public class DocumentLoaderTest {
     public void jarCacheMissThreadCtx() throws Exception {
         final URLClassLoader findNothingCL = new URLClassLoader(new URL[] {}, null);
         Thread.currentThread().setContextClassLoader(findNothingCL);
+        // Must create a new CloseableHttpClient as the previous instance will not pickup the new classloader due to caching
+        documentLoader.setHttpClient(JsonUtils.createDefaultHttpClient());
         JsonUtils.fromURL(new URL("http://nonexisting.example.com/context"),
                 documentLoader.getHttpClient());
     }
@@ -321,6 +323,8 @@ public class DocumentLoaderTest {
 
         final ClassLoader cl = new URLClassLoader(new URL[] { nestedJar });
         Thread.currentThread().setContextClassLoader(cl);
+        // Must create a new CloseableHttpClient as the previous instance will not pickup the new classloader due to caching
+        documentLoader.setHttpClient(JsonUtils.createDefaultHttpClient());
         final Object hello = JsonUtils.fromURL(url, documentLoader.getHttpClient());
         assertTrue(hello instanceof Map);
         assertEquals("World!", ((Map) hello).get("Hello"));


### PR DESCRIPTION
This PR patches the ``JarCacheStorage`` so that it doesn't parse the entire classpath each time looking for ``jarcache.json`` resources by caching the first pass into a ``List`` and using it in future calls.

It might introduce some issues for users whose application frameworks rely on switching the context classloader, but those issues may already have existed per the use of the static ``JsonUtils.DEFAULT_HTTP_CLIENT`` to avoid creating new instances of ``CloseableHttpClient`` and to cache inside of a single instance of ``JarCacheStorage``. The issues are worked around in tests by replacing the ``DocumentLoader``s ``CloseableHttpClient`` with a new instance after replacing the context ``ClassLoader``, but not sure if that is symptomatic of a broader issue for application frameworks.