### PR TITLE
Exclude Guava imports in OSGi metadata

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,6 +112,7 @@
 				<configuration>
 					<instructions>
 						<Import-Package>
+							!com.google.common.*,
 							org.slf4j.*; version="[1.0.0,2)",
 							*
 						</Import-Package>


### PR DESCRIPTION
The Guava shading in v0.12 works great in an ordinary class loading context, but I have had trouble with OSGi. For example, the `jsonld-java` bundle's OSGi metadata contains:

```
[IMPEXP]
Import-Package
  ...
  com.google.common.cache                {version=[24.1,25)}
  com.google.common.collect              {version=[24.1,25)}
```

And so, in order to provision v0.12 in Karaf, I need to also install Guava 24.1. But given the shading that is already done on the Guava classes (and the inclusion of those classes in the `jsonld-java` jar, it should not be necessary to depend on an external Guava bundle.

It appears that the `maven-bundle-plugin` doesn't take the relocation of these packages into consideration when it generates the list of import dependencies. The change in this PR explicitly ignores the `com.google.common.*` classes, making it easier to provision `jsonld-java` in an OSGi environment (without having to also provision Guava/24.1)