### PR TITLE
Fix 226

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ System.out.println(JsonUtils.toPrettyString(compact));
 Processor options
 -----------------
 
-The Options specified by the [JSON-LD API Specification](http://json-ld.org/spec/latest/json-ld-api/#jsonldoptions) are accessible via the `com.github.jsonldjava.core.JsonLdOptions` class, and each `JsonLdProcessor.*` function has an optional input to take an instance of this class.
+The Options specified by the [JSON-LD API Specification](https://json-ld.org/spec/latest/json-ld-api/#the-jsonldoptions-type) are accessible via the `com.github.jsonldjava.core.JsonLdOptions` class, and each `JsonLdProcessor.*` function has an optional input to take an instance of this class.
 
 
 Controlling network traffic
@@ -448,6 +448,11 @@ Alternatively, we can also host your repository in the jsonld-java organisation 
 
 CHANGELOG
 =========
+
+### 2018-07-07
+* make pruneBlankNodeIdentifiers false by default in 1.0 mode and always true in 1.1 mode
+* fix issue with blank node identifier pruning when @id is aliased
+* allow wildcard {} for @id in framing
 
 ### 2018-07-07
 * Fix tests setup for schema.org with HttpURLConnection that break because of the inability of HttpURLConnection to redirect from HTTP to HTTPS

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -1712,7 +1712,6 @@ public class JsonLdApi {
         // 1. Node matches if it has an @id property including any IRI or
         // blank node in the @id property in frame.
         if (frameIds != null) {
-            System.out.println(frameIds.getClass());
             if (frameIds instanceof String) {
                 final Object nodeId = node.get(JsonLdConsts.ID);
                 if (nodeId == null) {
@@ -1721,7 +1720,7 @@ public class JsonLdApi {
                 if (JsonLdUtils.deepCompare(nodeId, frameIds)) {
                     return true;
                 }
-            } else if (frameIds instanceof LinkedHashMap) {
+            } else if (frameIds instanceof LinkedHashMap && ((LinkedHashMap) frameIds).size() == 0) {
                 if (node.containsKey(JsonLdConsts.ID)) {
                     return true;
                 }

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -271,7 +271,7 @@ public class JsonLdApi {
                                 }
                                 if (value instanceof List) {
                                     ((List<Object>) result.get(property))
-                                            .addAll((List<Object>) value);
+                                    .addAll((List<Object>) value);
                                 } else {
                                     ((List<Object>) result.get(property)).add(value);
                                 }
@@ -373,7 +373,7 @@ public class JsonLdApi {
                                         // true
                                         activeCtx.compactIri(JsonLdConsts.INDEX, true),
                                         ((Map<String, Object>) expandedItem)
-                                                .get(JsonLdConsts.INDEX));
+                                        .get(JsonLdConsts.INDEX));
                             }
                         }
                         // 7.6.4.3)
@@ -398,7 +398,7 @@ public class JsonLdApi {
                         // 7.6.5.2)
                         if (JsonLdConsts.LANGUAGE.equals(container) && (compactedItem instanceof Map
                                 && ((Map<String, Object>) compactedItem)
-                                        .containsKey(JsonLdConsts.VALUE))) {
+                                .containsKey(JsonLdConsts.VALUE))) {
                             compactedItem = ((Map<String, Object>) compactedItem)
                                     .get(JsonLdConsts.VALUE);
                         }
@@ -443,7 +443,7 @@ public class JsonLdApi {
                             }
                             if (compactedItem instanceof List) {
                                 ((List<Object>) result.get(itemActiveProperty))
-                                        .addAll((List<Object>) compactedItem);
+                                .addAll((List<Object>) compactedItem);
                             } else {
                                 ((List<Object>) result.get(itemActiveProperty)).add(compactedItem);
                             }
@@ -721,7 +721,7 @@ public class JsonLdApi {
                                 // 7.4.11.2.2)
                                 if (item instanceof List) {
                                     ((List<Object>) result.get(property))
-                                            .addAll((List<Object>) item);
+                                    .addAll((List<Object>) item);
                                 } else {
                                     ((List<Object>) result.get(property)).add(item);
                                 }
@@ -752,7 +752,7 @@ public class JsonLdApi {
                                     if (item instanceof Map && (((Map<String, Object>) item)
                                             .containsKey(JsonLdConsts.VALUE)
                                             || ((Map<String, Object>) item)
-                                                    .containsKey(JsonLdConsts.LIST))) {
+                                            .containsKey(JsonLdConsts.LIST))) {
                                         throw new JsonLdError(Error.INVALID_REVERSE_PROPERTY_VALUE);
                                     }
                                     // 7.4.11.3.3.1.2)
@@ -893,7 +893,7 @@ public class JsonLdApi {
                         // 7.10.4.3)
                         if (item instanceof List) {
                             ((List<Object>) reverseMap.get(expandedProperty))
-                                    .addAll((List<Object>) item);
+                            .addAll((List<Object>) item);
                         } else {
                             ((List<Object>) reverseMap.get(expandedProperty)).add(item);
                         }
@@ -908,7 +908,7 @@ public class JsonLdApi {
                     // 7.11.2)
                     if (expandedValue instanceof List) {
                         ((List<Object>) result.get(expandedProperty))
-                                .addAll((List<Object>) expandedValue);
+                        .addAll((List<Object>) expandedValue);
                     } else {
                         ((List<Object>) result.get(expandedProperty)).add(expandedValue);
                     }
@@ -1044,7 +1044,7 @@ public class JsonLdApi {
 
     void generateNodeMap(Object element, Map<String, Object> nodeMap, String activeGraph,
             Object activeSubject, String activeProperty, Map<String, Object> list)
-            throws JsonLdError {
+                    throws JsonLdError {
         // 1)
         if (element instanceof List) {
             // 1.1)
@@ -1712,6 +1712,7 @@ public class JsonLdApi {
         // 1. Node matches if it has an @id property including any IRI or
         // blank node in the @id property in frame.
         if (frameIds != null) {
+            System.out.println(frameIds.getClass());
             if (frameIds instanceof String) {
                 final Object nodeId = node.get(JsonLdConsts.ID);
                 if (nodeId == null) {
@@ -1720,6 +1721,11 @@ public class JsonLdApi {
                 if (JsonLdUtils.deepCompare(nodeId, frameIds)) {
                     return true;
                 }
+            } else if (frameIds instanceof LinkedHashMap) {
+                if (node.containsKey(JsonLdConsts.ID)) {
+                    return true;
+                }
+                return false;
             } else if (!(frameIds instanceof List)) {
                 throw new JsonLdError(Error.SYNTAX_ERROR, "frame @id must be an array");
             } else {
@@ -2001,7 +2007,7 @@ public class JsonLdApi {
                 if (object.isBlankNode() || object.isIRI()) {
                     // 3.5.8.1-3)
                     nodeMap.get(object.getValue()).usages
-                            .add(new UsagesNode(node, predicate, value));
+                    .add(new UsagesNode(node, predicate, value));
                 }
             }
         }
@@ -2201,7 +2207,7 @@ public class JsonLdApi {
                             });
                         }
                         ((List<Object>) ((Map<String, Object>) bnodes.get(id)).get("quads"))
-                                .add(quad);
+                        .add(quad);
                     }
                 }
             }

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
@@ -66,7 +66,7 @@ public class JsonLdOptions {
     private Embed embed = Embed.LAST;
     private Boolean explicit = null;
     private Boolean omitDefault = null;
-    private Boolean pruneBlankNodeIdentifiers = true;
+    private Boolean pruneBlankNodeIdentifiers = false;
     private Boolean requireAll = false;
 
     // RDF conversion options :

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdOptions.java
@@ -133,7 +133,7 @@ public class JsonLdOptions {
     }
 
     public Boolean getPruneBlankNodeIdentifiers() {
-        return pruneBlankNodeIdentifiers && getProcessingMode().equals(JSON_LD_1_1);
+        return pruneBlankNodeIdentifiers || getProcessingMode().equals(JSON_LD_1_1);
     }
 
     public void setPruneBlankNodeIdentifiers(Boolean pruneBlankNodeIdentifiers) {

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
@@ -325,12 +325,9 @@ public class JsonLdProcessor {
         final Context activeCtx = api.context
                 .parse(((Map<String, Object>) frame).get(JsonLdConsts.CONTEXT));
         final List<Object> framed = api.frame(expandedInput, expandedFrame);
-
-
         if (opts.getPruneBlankNodeIdentifiers()) {
             JsonLdUtils.pruneBlankNodes(framed);
         }
-
         Object compacted = api.compact(activeCtx, null, framed, opts.getCompactArrays());
         if (!(compacted instanceof List)) {
             final List<Object> tmp = new ArrayList<Object>();

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
@@ -231,7 +231,7 @@ public class JsonLdUtils {
             }
 
             // recurse through properties
-            for (final String prop : new LinkedHashSet<>(((Map<String, Object>) input).keySet())) {
+            for (final String prop : ((Map<String, Object>) input).keySet()) {
                 Object result = removePreserve(ctx, ((Map<String, Object>) input).get(prop),
                         opts);
                 final String container = ctx.getContainer(prop);
@@ -239,6 +239,7 @@ public class JsonLdUtils {
                         && ((List<Object>) result).size() == 1 && container == null) {
                     result = ((List<Object>) result).get(0);
                 }
+                ((Map<String, Object>) input).put(prop, result);
             }
         }
         return input;

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jsonldjava.utils.JsonUtils;
 
 public class JsonLdFramingTest {
@@ -38,8 +37,6 @@ public class JsonLdFramingTest {
 
         final Object out = JsonUtils
                 .fromInputStream(getClass().getResourceAsStream("/custom/frame-0002-out.jsonld"));
-        // System.out.println(JsonUtils.toPrettyString(out));
-        // System.out.println(JsonUtils.toPrettyString(frame2));
         assertEquals(out, frame2);
     }
 
@@ -167,8 +164,6 @@ public class JsonLdFramingTest {
         final JsonLdOptions opts = new JsonLdOptions();
         opts.setProcessingMode("json-ld-1.1");
         final Map<String, Object> frame2 = JsonLdProcessor.frame(in, frame, opts);
-        ObjectMapper om = new ObjectMapper();
-        om.writeValue(System.out, frame2);
         final Object out = JsonUtils
                 .fromInputStream(getClass().getResourceAsStream("/custom/frame-0009-out.jsonld"));
         assertEquals(out, frame2);

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
@@ -139,4 +139,20 @@ public class JsonLdFramingTest {
                 .fromInputStream(getClass().getResourceAsStream("/custom/frame-0008-out.jsonld"));
         assertEquals(out, frame2);
     }
+
+    @Test
+    public void testFramep050() throws IOException, JsonLdError {
+        final Object frame = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/json-ld.org/frame-p050-frame.jsonld"));
+        final Object in = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/json-ld.org/frame-p050-in.jsonld"));
+
+        final JsonLdOptions opts = new JsonLdOptions();
+        opts.setProcessingMode("json-ld-1.1");
+        final Map<String, Object> frame2 = JsonLdProcessor.frame(in, frame, opts);
+
+        final Object out = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/json-ld.org/frame-p050-out.jsonld"));
+        assertEquals(out, frame2);
+    }
 }

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jsonldjava.utils.JsonUtils;
 
 public class JsonLdFramingTest {
@@ -153,6 +154,23 @@ public class JsonLdFramingTest {
 
         final Object out = JsonUtils
                 .fromInputStream(getClass().getResourceAsStream("/json-ld.org/frame-p050-out.jsonld"));
+        assertEquals(out, frame2);
+    }
+
+    @Test
+    public void testFrame0009() throws IOException, JsonLdError {
+        final Object frame = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0009-frame.jsonld"));
+        final Object in = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0009-in.jsonld"));
+
+        final JsonLdOptions opts = new JsonLdOptions();
+        opts.setProcessingMode("json-ld-1.1");
+        final Map<String, Object> frame2 = JsonLdProcessor.frame(in, frame, opts);
+        ObjectMapper om = new ObjectMapper();
+        om.writeValue(System.out, frame2);
+        final Object out = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0009-out.jsonld"));
         assertEquals(out, frame2);
     }
 }

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdProcessorTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdProcessorTest.java
@@ -416,12 +416,11 @@ public class JsonLdProcessorTest {
             if (test_opts.containsKey("useRdfType")) {
                 options.setUseRdfType((Boolean) test_opts.get("useRdfType"));
             }
+            if (test_opts.containsKey("processingMode")) {
+                options.setProcessingMode((String) test_opts.get("processingMode"));
+            }
             if (test_opts.containsKey("produceGeneralizedRdf")) {
                 options.setProduceGeneralizedRdf((Boolean) test_opts.get("produceGeneralizedRdf"));
-            }
-            if (test_opts.containsKey("pruneBlankNodeIdentifiers")) {
-                options.setPruneBlankNodeIdentifiers(
-                        (Boolean) test_opts.get("pruneBlankNodeIdentifiers"));
             }
             if (test_opts.containsKey("redirectTo")) {
                 testLoader.setRedirectTo((String) test_opts.get("redirectTo"));
@@ -553,7 +552,7 @@ public class JsonLdProcessorTest {
                     {
                         put("@id",
                                 "http://json-ld.org/test-suite/tests/error-expand-manifest.jsonld"
-                                        .equals(manifest) ? "earl:semiAuto" : "earl:automatic");
+                                .equals(manifest) ? "earl:semiAuto" : "earl:automatic");
                     }
                 });
             }

--- a/core/src/test/resources/custom/frame-0009-frame.jsonld
+++ b/core/src/test/resources/custom/frame-0009-frame.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id"
+  },
+  "id": {}
+}

--- a/core/src/test/resources/custom/frame-0009-in.jsonld
+++ b/core/src/test/resources/custom/frame-0009-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id"
+  },
+  "id": "_:bnode0",
+  "name": "bar",
+  "prop1": { "name": "foo", "id": "_:bnode1" },
+  "prop2": { "name": "foo", "id": "_:bnode1" }
+}

--- a/core/src/test/resources/custom/frame-0009-out.jsonld
+++ b/core/src/test/resources/custom/frame-0009-out.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "http:\/\/example\/",
+    "id": "@id"
+  },
+  "@graph": [
+    {
+      "name": "bar",
+      "prop1": {
+        "id": "_:b1"
+      },
+      "prop2": {
+        "id": "_:b1",
+        "name": "foo"
+      }
+    },
+    {
+      "id": "_:b1",
+      "name": "foo"
+    }
+  ]
+}

--- a/core/src/test/resources/json-ld.org/frame-manifest.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-manifest.jsonld
@@ -151,7 +151,8 @@
       "name": "Blank nodes in @type",
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
-      "expect": "frame-0021-out.jsonld"
+      "expect": "frame-0021-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     } , {
       "@id": "#t0022",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -167,34 +168,34 @@
       "frame": "frame-0030-frame.jsonld",
       "expect": "frame-0030-out.jsonld"
     }, {
-      "@id": "p0010",
+      "@id": "#tp010",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Property CURIE conflict (prune bnodes)",
-      "option" : {"pruneBlankNodeIdentifiers" : true},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "frame-0010-in.jsonld",
       "frame": "frame-0010-frame.jsonld",
       "expect": "frame-p010-out.jsonld"
     }, {
-      "@id": "p0020",
+      "@id": "#tp020",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Blank nodes in an array (prune bnodes)",
-      "option" : {"pruneBlankNodeIdentifiers" : true},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "frame-0020-in.jsonld",
       "frame": "frame-0020-frame.jsonld",
       "expect": "frame-p020-out.jsonld"
     }, {
-      "@id": "p0021",
+      "@id": "#tp021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Blank nodes in @type (prune bnodes)",
-      "option" : {"pruneBlankNodeIdentifiers" : true},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
       "expect": "frame-p021-out.jsonld"
     }, {
-      "@id": "p0046",
+      "@id": "#tp046",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge graphs if no outer @graph is used (prune bnodes)",
-      "option" : {"pruneBlankNodeIdentifiers" : true},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-p046-out.jsonld"

--- a/core/src/test/resources/json-ld.org/frame-manifest.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-manifest.jsonld
@@ -198,5 +198,14 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-p046-out.jsonld"
+    }, {
+      "@id": "#tp050",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Prune blank nodes with alias of @id",
+      "purpose": "If @id is aliased in a frame, an unreferenced blank node is still pruned.",
+      "input": "frame-p050-in.jsonld",
+      "frame": "frame-p050-frame.jsonld",
+      "expect": "frame-p050-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }]
 }

--- a/core/src/test/resources/json-ld.org/frame-p050-frame.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-p050-frame.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id"
+  },
+  "id": {},
+  "name": {}
+}

--- a/core/src/test/resources/json-ld.org/frame-p050-in.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-p050-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id"
+  },
+  "id": "_:bnode0",
+  "name": "foo"
+}

--- a/core/src/test/resources/json-ld.org/frame-p050-out.jsonld
+++ b/core/src/test/resources/json-ld.org/frame-p050-out.jsonld
@@ -1,0 +1,7 @@
+{
+ "@context": {
+   "@vocab": "http://example/",
+   "id": "@id"
+ },
+ "@graph": [{"name": "foo"}]
+}


### PR DESCRIPTION
fixes #226 

* make pruneBlankNodeIdentifiers false by default in 1.0 mode and always true in 1.1 mode
* fix issue with blank node identifier pruning when @id is aliased
* allow wildcard {} for @id in framing

@ansell if you don't have time to make a release, I can if you give me write access to the Github and Maven repo