### PR TITLE
Added fix for wrong rdf:type to @type conversion

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -1861,6 +1861,15 @@ public class JsonLdApi {
         public Map<String, Object> value = null;
     }
 
+    private class Node {
+        private String predicate;
+        private RDFDataset.Node object;
+        public Node(String predicate, RDFDataset.Node object) {
+            this.predicate = predicate;
+            this.object = object;
+        }
+    }
+
     private class NodeMapNode extends LinkedHashMap<String, Object> {
         public List<UsagesNode> usages = new ArrayList(4);
 
@@ -1968,48 +1977,61 @@ public class JsonLdApi {
             }
 
             // 3.5)
+            final Map<String, List<Node>> nodes = new HashMap<>();
+
             for (final RDFDataset.Quad triple : graph) {
                 final String subject = triple.getSubject().getValue();
                 final String predicate = triple.getPredicate().getValue();
                 final RDFDataset.Node object = triple.getObject();
+                final List<Node> list = nodes.getOrDefault(subject, new ArrayList());
+                list.add(new Node(predicate, object));
+                nodes.put(subject, list);
+            }
+            for (final Map.Entry<String, List<Node>> nodeEntry : nodes.entrySet()) {
+              final String subject = nodeEntry.getKey();
 
-                // 3.5.1+3.5.2)
-                NodeMapNode node;
-                if (!nodeMap.containsKey(subject)) {
-                    node = new NodeMapNode(subject);
-                    nodeMap.put(subject, node);
-                } else {
-                    node = nodeMap.get(subject);
-                }
+                for (final Node n : nodeEntry.getValue()) {
+                    final String predicate = n.predicate;
+                    final RDFDataset.Node object = n.object;
 
-                // 3.5.3)
-                if ((object.isIRI() || object.isBlankNode())
-                        && !nodeMap.containsKey(object.getValue())) {
-                    nodeMap.put(object.getValue(), new NodeMapNode(object.getValue()));
-                }
+                    // 3.5.1+3.5.2)
+                    NodeMapNode node;
+                    if (!nodeMap.containsKey(subject)) {
+                        node = new NodeMapNode(subject);
+                        nodeMap.put(subject, node);
+                    } else {
+                        node = nodeMap.get(subject);
+                    }
 
-                // 3.5.4)
-                if (RDF_TYPE.equals(predicate) && (object.isIRI() || object.isBlankNode())
-                        && !opts.getUseRdfType()) {
-                    JsonLdUtils.mergeValue(node, JsonLdConsts.TYPE, object.getValue());
-                    continue;
-                }
+                    // 3.5.3)
+                    if ((object.isIRI() || object.isBlankNode())
+                            && !nodeMap.containsKey(object.getValue())) {
+                        nodeMap.put(object.getValue(), new NodeMapNode(object.getValue()));
+                    }
 
-                // 3.5.5)
-                final Map<String, Object> value = object.toObject(opts.getUseNativeTypes());
+                    // 3.5.4)
+                    if (RDF_TYPE.equals(predicate) && (object.isIRI() || object.isBlankNode())
+                            && !opts.getUseRdfType() && !nodes.containsKey(object.getValue())) {
+                        JsonLdUtils.mergeValue(node, JsonLdConsts.TYPE, object.getValue());
+                        continue;
+                    }
 
-                // 3.5.6+7)
-                if (noDuplicatesInDataset) {
-                    JsonLdUtils.laxMergeValue(node, predicate, value);
-                } else {
-                    JsonLdUtils.mergeValue(node, predicate, value);
-                }
+                    // 3.5.5)
+                    final Map<String, Object> value = object.toObject(opts.getUseNativeTypes());
 
-                // 3.5.8)
-                if (object.isBlankNode() || object.isIRI()) {
-                    // 3.5.8.1-3)
-                    nodeMap.get(object.getValue()).usages
-                            .add(new UsagesNode(node, predicate, value));
+                    // 3.5.6+7)
+                    if (noDuplicatesInDataset) {
+                        JsonLdUtils.laxMergeValue(node, predicate, value);
+                    } else {
+                        JsonLdUtils.mergeValue(node, predicate, value);
+                    }
+
+                    // 3.5.8)
+                    if (object.isBlankNode() || object.isIRI()) {
+                        // 3.5.8.1-3)
+                        nodeMap.get(object.getValue()).usages
+                                .add(new UsagesNode(node, predicate, value));
+                    }
                 }
             }
         }

--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -1983,9 +1983,7 @@ public class JsonLdApi {
                 final String subject = triple.getSubject().getValue();
                 final String predicate = triple.getPredicate().getValue();
                 final RDFDataset.Node object = triple.getObject();
-                final List<Node> list = nodes.getOrDefault(subject, new ArrayList());
-                list.add(new Node(predicate, object));
-                nodes.put(subject, list);
+                nodes.computeIfAbsent(subject, k -> new ArrayList<>()).add(new Node(predicate, object));
             }
             for (final Map.Entry<String, List<Node>> nodeEntry : nodes.entrySet()) {
               final String subject = nodeEntry.getKey();
@@ -1995,13 +1993,7 @@ public class JsonLdApi {
                     final RDFDataset.Node object = n.object;
 
                     // 3.5.1+3.5.2)
-                    NodeMapNode node;
-                    if (!nodeMap.containsKey(subject)) {
-                        node = new NodeMapNode(subject);
-                        nodeMap.put(subject, node);
-                    } else {
-                        node = nodeMap.get(subject);
-                    }
+                    final NodeMapNode node = nodeMap.computeIfAbsent(subject, k -> new NodeMapNode(subject));
 
                     // 3.5.3)
                     if ((object.isIRI() || object.isBlankNode())

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
@@ -152,4 +152,29 @@ public class JsonLdFramingTest {
                 .fromInputStream(getClass().getResourceAsStream("/custom/frame-0009-out.jsonld"));
         assertEquals(out, frame2);
     }
+
+    @Test
+    public void testFrame0010() throws IOException, JsonLdError {
+        final Object frame = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0010-frame.jsonld"));
+        //{
+        //    "@id": "http://example.com/main/id",
+        //    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+        //      "@id": "http://example.com/rdf/id",
+        //      "http://www.w3.org/1999/02/22-rdf-syntax-ns#label": "someLabel"
+        //    }
+        //}
+        final RDFDataset ds = new RDFDataset();
+        ds.addTriple("http://example.com/main/id", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://example.com/rdf/id");
+        ds.addTriple("http://example.com/rdf/id", "http://www.w3.org/1999/02/22-rdf-syntax-ns#label", "someLabel", null, null);
+        final JsonLdOptions opts = new JsonLdOptions();
+        opts.setProcessingMode(JsonLdOptions.JSON_LD_1_0);
+
+        final Object in = new JsonLdApi(opts).fromRDF(ds, true);
+
+        final Map<String, Object> frame2 = JsonLdProcessor.frame(in, frame, opts);
+        final Object out = JsonUtils
+                .fromInputStream(getClass().getResourceAsStream("/custom/frame-0010-out.jsonld"));
+        assertEquals(out, frame2);
+    }
 }

--- a/core/src/test/resources/custom/frame-0010-frame.jsonld
+++ b/core/src/test/resources/custom/frame-0010-frame.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  },
+  "@id" : "http://example.com/main/id"
+}

--- a/core/src/test/resources/custom/frame-0010-out.jsonld
+++ b/core/src/test/resources/custom/frame-0010-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  },
+  "@graph" : [ {
+    "@id" : "http://example.com/main/id",
+    "rdf:type" : {
+      "@id" :  "http://example.com/rdf/id",
+      "rdf:label" : "someLabel"
+    }
+  }
+ ]
+}

--- a/core/src/test/resources/json-ld.org/fromRdf-0020-in.nq
+++ b/core/src/test/resources/json-ld.org/fromRdf-0020-in.nq
@@ -1,0 +1,7 @@
+<http://example.com/Subj1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/Type> .
+<http://example.com/Type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "myLabel" .
+<http://example.com/Type> <http://example.com/prop2> "2012-05-12"^^<http://www.w3.org/2001/XMLSchema#date> .
+<http://example.com/Subj1> <http://example.com/prop1> <http://example.com/Obj1> .
+<http://example.com/Subj1> <http://example.com/prop2> "Plain" .
+<http://example.com/Subj1> <http://example.com/prop2> "2012-05-12"^^<http://www.w3.org/2001/XMLSchema#date> .
+<http://example.com/Subj1> <http://example.com/prop2> "English"@en .

--- a/core/src/test/resources/json-ld.org/fromRdf-0020-out.jsonld
+++ b/core/src/test/resources/json-ld.org/fromRdf-0020-out.jsonld
@@ -1,0 +1,19 @@
+[
+  {
+    "@id": "http://example.com/Subj1",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : [{
+      "@id": "http://example.com/Type"
+    }],
+    "http://example.com/prop1": [{"@id": "http://example.com/Obj1"}],
+    "http://example.com/prop2": [
+      {"@value": "Plain"},
+      {"@value": "2012-05-12", "@type": "http://www.w3.org/2001/XMLSchema#date"},
+      {"@value": "English", "@language": "en"}
+    ]
+  },
+  {
+    "@id": "http://example.com/Type",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#label": [{"@value": "myLabel"}],
+    "http://example.com/prop2": [{"@value": "2012-05-12", "@type": "http://www.w3.org/2001/XMLSchema#date"}]
+  }
+]

--- a/core/src/test/resources/json-ld.org/fromRdf-manifest.jsonld
+++ b/core/src/test/resources/json-ld.org/fromRdf-manifest.jsonld
@@ -145,6 +145,13 @@
       },
       "input": "fromRdf-0019-in.nq",
       "expect": "fromRdf-0019-out.jsonld"
+    }, {
+      "@id": "#t0020",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
+      "name": "rdf:type as an @id with values",
+      "purpose": "Tests the proper formatting of @type (even with useRdfType to false) into rdf:type when the object contains more triples.",
+      "input": "fromRdf-0020-in.nq",
+      "expect": "fromRdf-0020-out.jsonld"
     }
   ]
 }


### PR DESCRIPTION
Fixes #242

As described on the issue, from the following triples
```
<http://example.com/Subj1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/Type> .
<http://example.com/Type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "myLabel" .
```
the following json should be created (event when useRdfType = false):
```json
{
   "@id": "http://example.com/Subj1",
   "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
      "http://www.w3.org/1999/02/22-rdf-syntax-ns#label": "myLabel"
   }
}
```
