### PR TITLE
Throw error on empty key in context

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -40,11 +40,13 @@ public class Context extends LinkedHashMap<String, Object> {
 
     public Context(Map<String, Object> map, JsonLdOptions opts) {
         super(map);
+        checkEmptyKey(map);
         init(opts);
     }
 
     public Context(Map<String, Object> map) {
         super(map);
+        checkEmptyKey(map);
         init(new JsonLdOptions());
     }
 
@@ -213,7 +215,7 @@ public class Context extends LinkedHashMap<String, Object> {
                 // 3.3
                 throw new JsonLdError(Error.INVALID_LOCAL_CONTEXT, context);
             }
-
+            checkEmptyKey((Map<String, Object>) context);
             // 3.4
             if (!parsingARemoteContext
                     && ((Map<String, Object>) context).containsKey(JsonLdConsts.BASE)) {
@@ -282,6 +284,15 @@ public class Context extends LinkedHashMap<String, Object> {
             }
         }
         return result;
+    }
+
+    private void checkEmptyKey(final Map<String, Object> map) {
+        if (map.containsKey("")) {
+            // the term MUST NOT be an empty string ("")
+            // https://www.w3.org/TR/json-ld/#h3_terms
+            throw new JsonLdError(Error.INVALID_TERM_DEFINITION,
+                    String.format("empty key for value '%s'", map.get("")));
+        }
     }
 
     public Context parse(Object localContext) throws JsonLdError {

--- a/core/src/test/java/com/github/jsonldjava/core/ContextTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextTest.java
@@ -2,10 +2,37 @@ package com.github.jsonldjava.core;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 public class ContextTest {
 
     @Test
     public void testRemoveBase() {
         // TODO: test if Context.removeBase actually works
     }
+
+    // See https://github.com/jsonld-java/jsonld-java/issues/141
+
+    @Test(expected = JsonLdError.class)
+    public void testIssue141_errorOnEmptyKey_compact() {
+        JsonLdProcessor.compact(ImmutableMap.of(),
+                ImmutableMap.of("","http://example.com"), new JsonLdOptions());
+    }
+
+    @Test(expected = JsonLdError.class)
+    public void testIssue141_errorOnEmptyKey_expand() {
+        JsonLdProcessor.expand(ImmutableMap.of("@context",
+                ImmutableMap.of("","http://example.com")), new JsonLdOptions());
+    }
+
+    @Test(expected = JsonLdError.class)
+    public void testIssue141_errorOnEmptyKey_newContext1() {
+        new Context(ImmutableMap.of("","http://example.com"));
+    }
+
+    @Test(expected = JsonLdError.class)
+    public void testIssue141_errorOnEmptyKey_newContext2() {
+        new Context(ImmutableMap.of("","http://example.com"), new JsonLdOptions());
+    }
+
 }


### PR DESCRIPTION
I think with this we can resolve #141.

The actual issue of producing invalid output from Jena has been fixed in Jena as described by @afs in https://github.com/jsonld-java/jsonld-java/issues/141#issuecomment-99384246. This pull request adds throwing an error as mentioned by @ansell in https://github.com/jsonld-java/jsonld-java/issues/141#issuecomment-99252669.