### PR TITLE
Update jackson to v2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
 		<httpclient.version>4.5.8</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
-		<jackson.version>2.9.8</jackson.version>
+		<jackson.version>2.9.9</jackson.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.26</slf4j.version>
 


### PR DESCRIPTION
Response to CVE-2019-12086 (which does not appear to impact this project).

But better to update to help downstream users who apply security scanners.
