### PR TITLE
Update version of jackson-databind to 2.9.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<httpcore.version>4.4.11</httpcore.version>
 		<jackson.version>2.9.9</jackson.version>
 		<!-- Point release fix for jackson-databind only -->
-		<jackson-databind.version>2.9.9.1</jackson-databind.version>
+		<jackson-databind.version>2.9.9.2</jackson-databind.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.26</slf4j.version>
 


### PR DESCRIPTION
More security issues - recommendation is now version 2.9.9.2.