### PR TITLE
Update version of jackson.core to 2.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,7 @@
 
 		<httpclient.version>4.5.8</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
-		<jackson.version>2.9.9</jackson.version>
-		<!-- Point release fix for jackson-databind only -->
-		<jackson-databind.version>2.9.9.2</jackson-databind.version>
+		<jackson.version>2.9.10</jackson.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.26</slf4j.version>
 
@@ -67,7 +65,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>${jackson-databind.version}</version>
+				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Update to 2.9.10 as now recommended:

Since 2.9.9.2, there have been:

Jackson 2.9.10 covers:
CVE-2019-14540
CVE-2019-16335

Jackson 2.9.9.3 addressed:
CVE-2019-14379

Because the versions of jackson-core and jackson-databind now align, remove the databind specific setting.