### PR TITLE
Update to Jackson 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
 		<httpclient.version>4.5.8</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
-		<jackson.version>2.9.10</jackson.version>
+		<jackson.version>2.10.0</jackson.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.26</slf4j.version>
 


### PR DESCRIPTION
This PR updates Jackson to 2.10.0 from 2.9.10. It passes "mvn verify".

2.10.x has a more secure "databind" component that should bring to the end the stream of 2.9.x updates for CVEs.

Background for the design change for the security:
https://blog.sonatype.com/jackson-databind-the-end-of-the-blacklist

Jackson 2.10 features - 2.x API backwards compatibility is a goal:
https://medium.com/@cowtowncoder/jackson-2-10-features-cd880674d8a2

Explanation of the databind vulnerability:
https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062