### PR TITLE
issue #293 : Add com.google.thirdparty to shading

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,6 +82,10 @@
 							<pattern>com.google.common</pattern>
 							<shadedPattern>com.github.jsonldjava.shaded.com.google.common</shadedPattern>
 						</relocation>
+						<relocation>
+							<pattern>com.google.thirdparty</pattern>
+							<shadedPattern>com.github.jsonldjava.shaded.com.google.thirdparty</shadedPattern>
+						</relocation>
 					</relocations>
 					<filters>
 						<filter>


### PR DESCRIPTION
This fixes an issue where google have bundled some guava code into a different top level package to the rest of guava.

Fixes #293 

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>