### PR TITLE
Throw RECURSIVE_CONTEXT_INCLUSION only when cyclic dependency exists

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -143,6 +143,9 @@ public class Context extends LinkedHashMap<String, Object> {
      */
     @SuppressWarnings("unchecked")
     public Context parse(Object localContext, List<String> remoteContexts) throws JsonLdError {
+        if (remoteContexts == null) {
+            remoteContexts = new ArrayList<String>();
+        }
         return parse(localContext, remoteContexts, false);
     }
 
@@ -163,11 +166,8 @@ public class Context extends LinkedHashMap<String, Object> {
      * @throws JsonLdError
      *             If there is an error parsing the contexts.
      */
-    private Context parse(Object localContext, List<String> remoteContexts,
+    private Context parse(Object localContext, final List<String> remoteContexts,
             boolean parsingARemoteContext) throws JsonLdError {
-        if (remoteContexts == null) {
-            remoteContexts = new ArrayList<String>();
-        }
         // 1. Initialize result to the result of cloning active context.
         Context result = this.clone(); // TODO: clone?
         // 2)
@@ -193,7 +193,8 @@ public class Context extends LinkedHashMap<String, Object> {
                 if (remoteContexts.contains(uri)) {
                     throw new JsonLdError(Error.RECURSIVE_CONTEXT_INCLUSION, uri);
                 }
-                remoteContexts.add(uri);
+                List<String> nextRemoteContexts = new ArrayList<>(remoteContexts);
+                nextRemoteContexts.add(uri);
 
                 // 3.2.3: Dereference context
                 final RemoteDocument rd = this.options.getDocumentLoader().loadDocument(uri);
@@ -208,7 +209,7 @@ public class Context extends LinkedHashMap<String, Object> {
                         .get(JsonLdConsts.CONTEXT);
 
                 // 3.2.4
-                result = result.parse(tempContext, remoteContexts, true);
+                result = result.parse(tempContext, nextRemoteContexts, true);
                 // 3.2.5
                 continue;
             } else if (!(context instanceof Map)) {

--- a/core/src/test/java/com/github/jsonldjava/core/ContextRecursionTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextRecursionTest.java
@@ -24,7 +24,7 @@ public class ContextRecursionTest {
     }
 
     @Test
-    public void testAllowedRecursion() throws IOException {
+    public void testIssue302_allowedRecursion() throws IOException {
 
         final String contextB = "{\"@context\": [\"http://localhost/d\", {\"b\": \"http://localhost/b\"} ] }";
         final String contextC = "{\"@context\": [\"http://localhost/d\", {\"c\": \"http://localhost/c\"} ] }";
@@ -67,8 +67,8 @@ public class ContextRecursionTest {
             JsonLdProcessor.expand(json, options);
             fail("it should throw");
         } catch(JsonLdError err) {
-            assertEquals(err.getType(), JsonLdError.Error.RECURSIVE_CONTEXT_INCLUSION);
-            assertEquals(err.getMessage(), "recursive context inclusion: http://localhost/c");
+            assertEquals(JsonLdError.Error.RECURSIVE_CONTEXT_INCLUSION, err.getType());
+            assertEquals("recursive context inclusion: http://localhost/c", err.getMessage());
         }
     }
 

--- a/core/src/test/java/com/github/jsonldjava/core/ContextRecursionTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextRecursionTest.java
@@ -1,0 +1,75 @@
+package com.github.jsonldjava.core;
+
+import com.github.jsonldjava.utils.JsonUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+
+public class ContextRecursionTest {
+
+    @BeforeClass
+    public static void setup() {
+        System.setProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING, "true");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        System.setProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING, "false");
+    }
+
+    @Test
+    public void testAllowedRecursion() throws IOException {
+
+        final String contextB = "{\"@context\": [\"http://localhost/d\", {\"b\": \"http://localhost/b\"} ] }";
+        final String contextC = "{\"@context\": [\"http://localhost/d\", {\"c\": \"http://localhost/c\"} ] }";
+        final String contextD = "{\"@context\": [\"http://localhost/e\", {\"d\": \"http://localhost/d\"} ] }";
+        final String contextE = "{\"@context\": {\"e\": \"http://localhost/e\"} }";
+
+        final DocumentLoader dl = new DocumentLoader();
+        dl.addInjectedDoc("http://localhost/b", contextB);
+        dl.addInjectedDoc("http://localhost/c", contextC);
+        dl.addInjectedDoc("http://localhost/d", contextD);
+        dl.addInjectedDoc("http://localhost/e", contextE);
+        final JsonLdOptions options = new JsonLdOptions();
+        options.setDocumentLoader(dl);
+
+        final String jsonString = "{\"@context\": [\"http://localhost/d\", \"http://localhost/b\", \"http://localhost/c\", {\"a\": \"http://localhost/a\"} ], \"a\": \"A\", \"b\": \"B\", \"c\": \"C\", \"d\": \"D\"}";
+        final Object json = JsonUtils.fromString(jsonString);
+        final Object expanded = JsonLdProcessor.expand(json, options);
+        assertEquals(
+                "[{http://localhost/a=[{@value=A}], http://localhost/b=[{@value=B}], http://localhost/c=[{@value=C}], http://localhost/d=[{@value=D}]}]",
+                expanded.toString());
+    }
+
+    @Test
+    public void testCyclicRecursion() throws IOException {
+
+        final String contextC = "{\"@context\": [\"http://localhost/d\", {\"c\": \"http://localhost/c\"} ] }";
+        final String contextD = "{\"@context\": [\"http://localhost/e\", {\"d\": \"http://localhost/d\"} ] }";
+        final String contextE = "{\"@context\": [\"http://localhost/c\", {\"e\": \"http://localhost/e\"} ] }";
+
+        final DocumentLoader dl = new DocumentLoader();
+        dl.addInjectedDoc("http://localhost/c", contextC);
+        dl.addInjectedDoc("http://localhost/d", contextD);
+        dl.addInjectedDoc("http://localhost/e", contextE);
+        final JsonLdOptions options = new JsonLdOptions();
+        options.setDocumentLoader(dl);
+
+        final String jsonString = "{\"@context\": [\"http://localhost/c\", {\"a\": \"http://localhost/a\"} ]}";
+        final Object json = JsonUtils.fromString(jsonString);
+        try {
+            JsonLdProcessor.expand(json, options);
+            fail("it should throw");
+        } catch(JsonLdError err) {
+            assertEquals(err.getType(), JsonLdError.Error.RECURSIVE_CONTEXT_INCLUSION);
+            assertEquals(err.getMessage(), "recursive context inclusion: http://localhost/c");
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/jsonld-java/jsonld-java/issues/302

The problem was with the fact that the list of visited remoteContexts was mutated while recursing.