### PR TITLE
Ignore @base if remote context is not relative

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import com.github.jsonldjava.core.JsonLdError.Error;
 import com.github.jsonldjava.utils.JsonLdUrl;
@@ -25,6 +26,7 @@ public class Context extends LinkedHashMap<String, Object> {
 
     private static final long serialVersionUID = 2894534897574805571L;
 
+    private static final Pattern URL_PATTERN = Pattern.compile("^https?://.*$", Pattern.CASE_INSENSITIVE);
     private JsonLdOptions options;
     private Map<String, Object> termDefinitions;
     public Map<String, Object> inverse = null;
@@ -189,7 +191,7 @@ public class Context extends LinkedHashMap<String, Object> {
             else if (context instanceof String) {
                 String uri = null;
                 // @base is ignored when processing remote contexts, https://github.com/jsonld-java/jsonld-java/issues/304
-                if (!context.toString().matches("^[hH][tT][tT][pP][sS]?://.*")) {
+                if (!URL_PATTERN.matcher(context.toString()).matches()) {
                     uri = (String) result.get(JsonLdConsts.BASE);
                 }
                 uri = JsonLdUrl.resolve(uri, (String) context);

--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -143,7 +143,6 @@ public class Context extends LinkedHashMap<String, Object> {
      * @throws JsonLdError
      *             If there is an error parsing the contexts.
      */
-    @SuppressWarnings("unchecked")
     public Context parse(Object localContext, List<String> remoteContexts) throws JsonLdError {
         return parse(localContext, remoteContexts, false);
     }

--- a/core/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/core/src/main/java/com/github/jsonldjava/core/Context.java
@@ -187,7 +187,11 @@ public class Context extends LinkedHashMap<String, Object> {
             }
             // 3.2)
             else if (context instanceof String) {
-                String uri = (String) result.get(JsonLdConsts.BASE);
+                String uri = null;
+                // @base is ignored when processing remote contexts, https://github.com/jsonld-java/jsonld-java/issues/304
+                if (!context.toString().matches("^[hH][tT][tT][pP][sS]?://.*")) {
+                    uri = (String) result.get(JsonLdConsts.BASE);
+                }
                 uri = JsonLdUrl.resolve(uri, (String) context);
                 // 3.2.2
                 if (remoteContexts.contains(uri)) {

--- a/core/src/test/java/com/github/jsonldjava/core/DocumentLoaderTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/DocumentLoaderTest.java
@@ -381,11 +381,19 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void injectContext() throws Exception {
+    public void testInjectContext() throws Exception {
+        injectContext(new JsonLdOptions());
+    }
+
+    @Test
+    public void testIssue304_remoteContextAndBaseIri() throws Exception {
+        injectContext(new JsonLdOptions("testing:baseIri"));
+    }
+
+    private void injectContext(final JsonLdOptions options) throws Exception {
 
         final Object jsonObject = JsonUtils.fromString(
                 "{ \"@context\":\"http://nonexisting.example.com/thing\", \"pony\":5 }");
-        final JsonLdOptions options = new JsonLdOptions();
 
         // Verify fails to find context by default
         try {


### PR DESCRIPTION
If the remote context is not relative and seems to be a http URI
don't prefix the base IRI to it.

The remote context is not validated nor tested if it's resolvable.
It's just tested if it's not a relative URI - which is totally possible
and would, in conjunction with a base IRI, made into valid remote
context.

See #304.