### PR TITLE
rdfToJson edge case when object = subject and predicate = rdf:type

### DIFF
--- a/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -2001,7 +2001,8 @@ public class JsonLdApi {
 
                     // 3.5.4)
                     if (RDF_TYPE.equals(predicate) && (object.isIRI() || object.isBlankNode())
-                            && !opts.getUseRdfType() && !nodes.containsKey(object.getValue())) {
+                            && !opts.getUseRdfType() &&
+                            (!nodes.containsKey(object.getValue()) || subject.equals(object.getValue()))) {
                         JsonLdUtils.mergeValue(node, JsonLdConsts.TYPE, object.getValue());
                         continue;
                     }

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdToRdfTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdToRdfTest.java
@@ -1,0 +1,31 @@
+package com.github.jsonldjava.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonLdToRdfTest {
+
+    @Test
+    public void testIssue301() throws JsonLdError {
+        final RDFDataset rdf = new RDFDataset();
+        rdf.addTriple(
+                "http://www.w3.org/2002/07/owl#Class",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                "http://www.w3.org/2002/07/owl#Class");
+        final JsonLdOptions opts = new JsonLdOptions();
+        opts.setUseRdfType(Boolean.FALSE);
+        opts.setProcessingMode(JsonLdOptions.JSON_LD_1_0);
+
+        final Object out = new JsonLdApi(opts).fromRDF(rdf, true);
+        assertEquals("[{@id=http://www.w3.org/2002/07/owl#Class, @type=[http://www.w3.org/2002/07/owl#Class]}]",
+                out.toString());
+
+        opts.setUseRdfType(Boolean.TRUE);
+
+        final Object out2 = new JsonLdApi(opts).fromRDF(rdf, true);
+        assertEquals("[{@id=http://www.w3.org/2002/07/owl#Class, http://www.w3.org/1999/02/22-rdf-syntax-ns#type=[{@id=http://www.w3.org/2002/07/owl#Class}]}]",
+                out2.toString());
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/jsonld-java/jsonld-java/issues/301

It seems that when [fixing a previous issue with rdfToJson (related to @type)](https://github.com/jsonld-java/jsonld-java/pull/245) I introduced this bug. 