### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<httpclient.version>4.5.12</httpclient.version>
-		<httpcore.version>4.4.13</httpcore.version>
-		<jackson.version>2.11.2</jackson.version>
+		<httpclient.version>4.5.13</httpclient.version>
+		<httpcore.version>4.4.14</httpcore.version>
+		<jackson.version>2.11.4</jackson.version>
 		<junit.version>4.13</junit.version>
 		<slf4j.version>1.7.30</slf4j.version>
 
@@ -202,7 +202,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.7</version>
+				<version>2.8.0</version>
 			</dependency>
 			<!-- Reuse Guava, but shade it to avoid transitive classpath issues for 
 				users given the high major release rate -->


### PR DESCRIPTION
Fix for #311 

- Newer version of Apache Commons-IO, HttpCore and HttpClient
- Newer version of Jackson (fixes a CVE, probably not an issue for jsonld-java, but can be a warning sign in other projects / strict environments)

Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>