### PR TITLE
issue #322 : Switch test logging from log4j to logback

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,8 +53,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, R
-
-log4j.appender.R=org.apache.log4j.ConsoleAppender
-log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=[%d] %-5p (%c:%L) %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
 		<httpcore.version>4.4.14</httpcore.version>
 		<jackson.version>2.11.4</jackson.version>
 		<junit.version>4.13.2</junit.version>
-		<slf4j.version>1.7.30</slf4j.version>
+		<slf4j.version>1.7.32</slf4j.version>
+		<logback.version>1.2.7</logback.version>
 
 		<last-compare-version>0.11.0</last-compare-version>
 	</properties>
@@ -96,9 +97,9 @@
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-log4j12</artifactId>
-				<version>${slf4j.version}</version>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>${logback.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Switch our tests to log using logback rather than log4j.

Avoiding possible issue with log4j due to https://nvd.nist.gov/vuln/detail/CVE-2021-44228 , even though it was only in the `test` scope and unlikely to be pushed to downstream without them explicitly choosing log4j as their slf4j logger implementation.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>