### PR TITLE
Migration to Junit5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,8 +48,8 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -63,6 +63,17 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.10.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<build>
 		<plugins>
 			<!-- Shade Google Guava into jsonld-java to avoid downstream incompatibilities 

--- a/core/src/test/java/com/github/jsonldjava/core/ArrayContextToRDFTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ArrayContextToRDFTest.java
@@ -1,18 +1,18 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
-public class ArrayContextToRDFTest {
+class ArrayContextToRDFTest {
     @Test
-    public void toRdfWithNamespace() throws Exception {
+    void toRdfWithNamespace() throws Exception {
 
         final URL contextUrl = getClass().getResource("/custom/contexttest-0001.jsonld");
         assertNotNull(contextUrl);

--- a/core/src/test/java/com/github/jsonldjava/core/ContextCompactionTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextCompactionTest.java
@@ -1,15 +1,15 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import com.github.jsonldjava.utils.JsonUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ContextCompactionTest {
@@ -39,9 +39,9 @@ public class ContextCompactionTest {
         newContexts.add("http://schema.org/");
         final Map<String, Object> compacted = JsonLdProcessor.compact(json, newContexts, options);
 
-        assertTrue("Compaction removed the context", compacted.containsKey("@context"));
-        assertFalse("Compaction of context should be a string, not a list",
-                compacted.get("@context") instanceof List);
+        assertTrue(compacted.containsKey("@context"), "Compaction removed the context");
+        assertFalse(compacted.get("@context") instanceof List,
+                "Compaction of context should be a string, not a list");
     }
 
     @Test
@@ -56,9 +56,9 @@ public class ContextCompactionTest {
 
         final Map<String, Object> compacted = JsonLdProcessor.compact(json, ctx, options);
 
-        assertEquals("Wrong returned context", "http://schema.org/", compacted.get("@context"));
-        assertEquals("Wrong type", "Person", compacted.get("type"));
-        assertEquals("Wrong number of Json entries",2, compacted.size());
+        assertEquals("http://schema.org/", compacted.get("@context"),"Wrong returned context");
+        assertEquals( "Person", compacted.get("type"),"Wrong type");
+        assertEquals(2, compacted.size(),"Wrong number of Json entries");
     }
 
 }

--- a/core/src/test/java/com/github/jsonldjava/core/ContextFlatteningTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextFlatteningTest.java
@@ -1,15 +1,15 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import com.github.jsonldjava.utils.JsonUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ContextFlatteningTest {
 
@@ -40,9 +40,9 @@ public class ContextFlatteningTest {
 
         final Map<String, Object> flattened = ((Map<String, Object>)JsonLdProcessor.flatten(json, flatten, options));
 
-        assertTrue("Flattening removed the context", flattened.containsKey("@context"));
-        assertFalse("Flattening of context should be a string, not a list",
-                flattened.get("@context") instanceof List);
+        assertTrue(flattened.containsKey("@context"),"Flattening removed the context");
+        assertFalse(flattened.get("@context") instanceof List,
+                "Flattening of context should be a string, not a list");
     }
 
     @Test
@@ -59,8 +59,8 @@ public class ContextFlatteningTest {
 
         final Map<String, Object> flattened = ((Map<String, Object>)JsonLdProcessor.flatten(json, flatten, options));
 
-        assertEquals("Wrong returned context", "http://schema.org/", flattened.get("@context"));
-        assertEquals("Wrong number of Json entries",2, flattened.size());
+        assertEquals("http://schema.org/", flattened.get("@context"),"Wrong returned context");
+        assertEquals(2, flattened.size(),"Wrong number of Json entries");
     }
 
 }

--- a/core/src/test/java/com/github/jsonldjava/core/ContextFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextFramingTest.java
@@ -1,15 +1,15 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import com.github.jsonldjava.utils.JsonUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ContextFramingTest {
 
@@ -40,9 +40,9 @@ public class ContextFramingTest {
 
         final Map<String, Object> framed = JsonLdProcessor.frame(json, frame, options);
 
-        assertTrue("Framing removed the context", framed.containsKey("@context"));
-        assertFalse("Framing of context should be a string, not a list",
-                framed.get("@context") instanceof List);
+        assertTrue(framed.containsKey("@context"), "Framing removed the context");
+        assertFalse(framed.get("@context") instanceof List,
+                "Framing of context should be a string, not a list");
     }
 
     @Test
@@ -58,10 +58,10 @@ public class ContextFramingTest {
 
         final Map<String, Object> framed = JsonLdProcessor.frame(json, frame, options);
 
-        assertEquals("Wrong returned context", "http://schema.org/", framed.get("@context"));
-        assertEquals("Wrong id", "schema:myid", framed.get("id"));
-        assertEquals("Wrong type", "Person", framed.get("type"));
-        assertEquals("Wrong number of Json entries",3, framed.size());
+        assertEquals("http://schema.org/", framed.get("@context"),"Wrong returned context");
+        assertEquals("schema:myid", framed.get("id"),"Wrong id");
+        assertEquals( "Person", framed.get("type"),"Wrong type");
+        assertEquals(3, framed.size(),"Wrong number of Json entries");
     }
 
 }

--- a/core/src/test/java/com/github/jsonldjava/core/ContextRecursionTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextRecursionTest.java
@@ -1,30 +1,30 @@
 package com.github.jsonldjava.core;
 
 import com.github.jsonldjava.utils.JsonUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
-public class ContextRecursionTest {
+class ContextRecursionTest {
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         System.setProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING, "true");
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         System.setProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING, "false");
     }
 
     @Test
-    public void testIssue302_allowedRecursion() throws IOException {
+    void issue302_allowedRecursion() throws IOException {
 
         final String contextB = "{\"@context\": [\"http://localhost/d\", {\"b\": \"http://localhost/b\"} ] }";
         final String contextC = "{\"@context\": [\"http://localhost/d\", {\"c\": \"http://localhost/c\"} ] }";
@@ -48,7 +48,7 @@ public class ContextRecursionTest {
     }
 
     @Test
-    public void testCyclicRecursion() throws IOException {
+    void cyclicRecursion() throws IOException {
 
         final String contextC = "{\"@context\": [\"http://localhost/d\", {\"c\": \"http://localhost/c\"} ] }";
         final String contextD = "{\"@context\": [\"http://localhost/e\", {\"d\": \"http://localhost/d\"} ] }";

--- a/core/src/test/java/com/github/jsonldjava/core/ContextSerializationTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextSerializationTest.java
@@ -1,24 +1,24 @@
 package com.github.jsonldjava.core;
 
 import com.github.jsonldjava.utils.JsonUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ContextSerializationTest {
+class ContextSerializationTest {
 
-    @Test
     // Added in order to have some coverage on the serialize method since is not used anywhere.
-    public void serializeTest() throws IOException {
-        final Map<String, Object> json = (Map<String, Object>)JsonUtils
+    @Test
+    void serializeTest() throws IOException {
+        final Map<String, Object> json = (Map<String, Object>) JsonUtils
                 .fromInputStream(getClass().getResourceAsStream("/custom/contexttest-0005.jsonld"));
 
         final Map<String, Object> contextValue = (Map<String, Object>)json.get(JsonLdConsts.CONTEXT);
         final Map<String, Object> serializedContext = new Context().parse(contextValue).serialize();
 
-        assertEquals("Wrong serialized context", json, serializedContext);
+        assertEquals(json, serializedContext, "Wrong serialized context");
     }
 }

--- a/core/src/test/java/com/github/jsonldjava/core/ContextTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/ContextTest.java
@@ -1,45 +1,54 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
-public class ContextTest {
+class ContextTest {
 
     @Test
-    public void testRemoveBase() {
+    void removeBase() {
         // TODO: test if Context.removeBase actually works
     }
 
     // See https://github.com/jsonld-java/jsonld-java/issues/141
 
-    @Test(expected = JsonLdError.class)
-    public void testIssue141_errorOnEmptyKey_compact() {
-        JsonLdProcessor.compact(ImmutableMap.of(), ImmutableMap.of("", "http://example.com"),
-                new JsonLdOptions());
+    @Test
+    void issue141_errorOnEmptyKey_compact() {
+        assertThrows(JsonLdError.class, () -> {
+            JsonLdProcessor.compact(ImmutableMap.of(), ImmutableMap.of("", "http://example.com"),
+                    new JsonLdOptions());
+        });
     }
 
-    @Test(expected = JsonLdError.class)
-    public void testIssue141_errorOnEmptyKey_expand() {
-        JsonLdProcessor.expand(
-                ImmutableMap.of("@context", ImmutableMap.of("", "http://example.com")),
-                new JsonLdOptions());
+    @Test
+    void issue141_errorOnEmptyKey_expand() {
+        assertThrows(JsonLdError.class, () -> {
+            JsonLdProcessor.expand(
+                    ImmutableMap.of("@context", ImmutableMap.of("", "http://example.com")),
+                    new JsonLdOptions());
+        });
     }
 
-    @Test(expected = JsonLdError.class)
-    public void testIssue141_errorOnEmptyKey_newContext1() {
-        new Context(ImmutableMap.of("", "http://example.com"));
+    @Test
+    void issue141_errorOnEmptyKey_newContext1() {
+        assertThrows(JsonLdError.class, () -> {
+            new Context(ImmutableMap.of("", "http://example.com"));
+        });
     }
 
-    @Test(expected = JsonLdError.class)
-    public void testIssue141_errorOnEmptyKey_newContext2() {
-        new Context(ImmutableMap.of("", "http://example.com"), new JsonLdOptions());
+    @Test
+    void issue141_errorOnEmptyKey_newContext2() {
+        assertThrows(JsonLdError.class, () -> {
+            new Context(ImmutableMap.of("", "http://example.com"), new JsonLdOptions());
+        });
     }
 
     /*
@@ -52,14 +61,16 @@ public class ContextTest {
 
     // See https://github.com/jsonld-java/jsonld-java/issues/248
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIssue248_uriExpected() {
-        JsonLdProcessor
-                .expand(ImmutableMap.of("roleName", "Production Company", "@context", schemaOrg));
+    @Test
+    void issue248_uriExpected() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            JsonLdProcessor
+                    .expand(ImmutableMap.of("roleName", "Production Company", "@context", schemaOrg));
+        });
     }
 
     @Test
-    public void testIssue248_forceValue() {
+    void issue248_forceValue() {
         final List<?> value = Arrays.asList(ImmutableMap.of("@value", "Production Company"));
         final Map<String, Object> input = ImmutableMap.of("roleName", value, "@context", schemaOrg);
         final Object output = JsonLdProcessor.expand(input);
@@ -68,7 +79,7 @@ public class ContextTest {
     }
 
     @Test
-    public void testIssue248_overrideContext() {
+    void issue248_overrideContext() {
         final List<?> context = Arrays.asList(schemaOrg,
                 ImmutableMap.of("roleName", ImmutableMap.of("@id", "http://schema.org/roleName")));
         final Map<String, Object> input = ImmutableMap.of("roleName", "Production Company",

--- a/core/src/test/java/com/github/jsonldjava/core/DecimalLiteralCanonicalTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/DecimalLiteralCanonicalTest.java
@@ -1,12 +1,12 @@
 package com.github.jsonldjava.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DecimalLiteralCanonicalTest {
     

--- a/core/src/test/java/com/github/jsonldjava/core/DocumentLoaderTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/DocumentLoaderTest.java
@@ -1,13 +1,6 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,25 +32,25 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
 @SuppressWarnings("unchecked")
-public class DocumentLoaderTest {
+class DocumentLoaderTest {
 
     private final DocumentLoader documentLoader = new DocumentLoader();
 
-    @After
-    public void setContextClassLoader() {
+    @AfterEach
+    void setContextClassLoader() {
         Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
     }
 
     @Test
-    public void fromURLTest0001() throws Exception {
+    void fromURLTest0001() throws Exception {
         final URL contexttest = getClass().getResource("/custom/contexttest-0001.jsonld");
         assertNotNull(contexttest);
         final Object context = JsonUtils.fromURL(contexttest, documentLoader.getHttpClient());
@@ -72,7 +65,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void fromURLTest0002() throws Exception {
+    void fromURLTest0002() throws Exception {
         final URL contexttest = getClass().getResource("/custom/contexttest-0002.jsonld");
         assertNotNull(contexttest);
         final Object context = JsonUtils.fromURL(contexttest, documentLoader.getHttpClient());
@@ -96,7 +89,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void fromURLBomTest0004() throws Exception {
+    void fromURLBomTest0004() throws Exception {
         final URL contexttest = getClass().getResource("/custom/contexttest-0004.jsonld");
         assertNotNull(contexttest);
         final Object context = JsonUtils.fromURL(contexttest, documentLoader.getHttpClient());
@@ -106,7 +99,7 @@ public class DocumentLoaderTest {
 
     // @Ignore("Integration test")
     @Test
-    public void fromURLredirectHTTPSToHTTP() throws Exception {
+    void fromURLredirectHTTPSToHTTP() throws Exception {
         final URL url = new URL("https://w3id.org/bundle/context");
         final Object context = JsonUtils.fromURL(url, documentLoader.getHttpClient());
         // Should not fail because of
@@ -118,7 +111,7 @@ public class DocumentLoaderTest {
 
     // @Ignore("Integration test")
     @Test
-    public void fromURLredirect() throws Exception {
+    void fromURLredirect() throws Exception {
         final URL url = new URL("http://purl.org/wf4ever/ro-bundle/context.json");
         final Object context = JsonUtils.fromURL(url, documentLoader.getHttpClient());
         assertTrue(context instanceof Map);
@@ -127,7 +120,7 @@ public class DocumentLoaderTest {
 
     // @Ignore("Integration test")
     @Test
-    public void loadDocumentWf4ever() throws Exception {
+    void loadDocumentWf4ever() throws Exception {
         final RemoteDocument document = documentLoader
                 .loadDocument("http://purl.org/wf4ever/ro-bundle/context.json");
         final Object context = document.getDocument();
@@ -135,9 +128,9 @@ public class DocumentLoaderTest {
         assertFalse(((Map<?, ?>) context).isEmpty());
     }
 
-    @Ignore("Schema.org started to redirect from HTTP to HTTPS which breaks the Java HttpURLConnection API")
+    @Disabled("Schema.org started to redirect from HTTP to HTTPS which breaks the Java HttpURLConnection API")
     @Test
-    public void fromURLSchemaOrgNoApacheHttpClient() throws Exception {
+    void fromURLSchemaOrgNoApacheHttpClient() throws Exception {
         final URL url = new URL("http://schema.org/");
 
         final HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
@@ -153,7 +146,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void loadDocumentSchemaOrg() throws Exception {
+    void loadDocumentSchemaOrg() throws Exception {
         final RemoteDocument document = documentLoader.loadDocument("http://schema.org/");
         final Object context = document.getDocument();
         assertTrue(context instanceof Map);
@@ -161,7 +154,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void loadDocumentSchemaOrgDirect() throws Exception {
+    void loadDocumentSchemaOrgDirect() throws Exception {
         final RemoteDocument document = documentLoader
                 .loadDocument("http://schema.org/docs/jsonldcontext.json");
         final Object context = document.getDocument();
@@ -169,9 +162,9 @@ public class DocumentLoaderTest {
         assertFalse(((Map<?, ?>) context).isEmpty());
     }
 
-    @Ignore("Caching failed without any apparent cause on the client side")
+    @Disabled("Caching failed without any apparent cause on the client side")
     @Test
-    public void fromURLCache() throws Exception {
+    void fromURLCache() throws Exception {
         final URL url = new URL("https://json-ld.org/contexts/person.jsonld");
         JsonUtils.fromURL(url, documentLoader.getHttpClient());
 
@@ -192,7 +185,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void fromURLCustomHandler() throws Exception {
+    void fromURLCustomHandler() throws Exception {
         final AtomicInteger requests = new AtomicInteger();
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
@@ -235,7 +228,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void fromURLAcceptHeaders() throws Exception {
+    void fromURLAcceptHeaders() throws Exception {
 
         final URL url = new URL("http://example.com/fake-jsonld-test");
         final ArgumentCaptor<HttpUriRequest> httpRequest = ArgumentCaptor
@@ -284,7 +277,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void jarCacheHit() throws Exception {
+    void jarCacheHit() throws Exception {
         // If no cache, should fail-fast as nonexisting.example.com is not in
         // DNS
         final Object context = JsonUtils.fromURL(new URL("http://nonexisting.example.com/context"),
@@ -293,23 +286,27 @@ public class DocumentLoaderTest {
         assertTrue(((Map) context).containsKey("@context"));
     }
 
-    @Test(expected = IOException.class)
-    public void jarCacheMiss404() throws Exception {
-        // Should fail-fast as nonexisting.example.com is not in DNS
-        JsonUtils.fromURL(new URL("http://nonexisting.example.com/miss"),
-                documentLoader.getHttpClient());
-    }
-
-    @Test(expected = IOException.class)
-    public void jarCacheMissThreadCtx() throws Exception {
-        final URLClassLoader findNothingCL = new URLClassLoader(new URL[] {}, null);
-        Thread.currentThread().setContextClassLoader(findNothingCL);
-        JsonUtils.fromURL(new URL("http://nonexisting.example.com/context"),
-                documentLoader.getHttpClient());
+    @Test
+    void jarCacheMiss404() throws Exception {
+        assertThrows(IOException.class, () -> {
+            // Should fail-fast as nonexisting.example.com is not in DNS
+            JsonUtils.fromURL(new URL("http://nonexisting.example.com/miss"),
+                    documentLoader.getHttpClient());
+        });
     }
 
     @Test
-    public void jarCacheHitThreadCtx() throws Exception {
+    void jarCacheMissThreadCtx() throws Exception {
+        assertThrows(IOException.class, () -> {
+            final URLClassLoader findNothingCL = new URLClassLoader(new URL[]{}, null);
+            Thread.currentThread().setContextClassLoader(findNothingCL);
+            JsonUtils.fromURL(new URL("http://nonexisting.example.com/context"),
+                    documentLoader.getHttpClient());
+        });
+    }
+
+    @Test
+    void jarCacheHitThreadCtx() throws Exception {
         final URL url = new URL("http://nonexisting.example.com/nested/hello");
         final URL nestedJar = getClass().getResource("/nested.jar");
         try {
@@ -335,13 +332,13 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void sharedHttpClient() throws Exception {
+    void sharedHttpClient() throws Exception {
         // Should be the same instance unless explicitly set
         assertSame(documentLoader.getHttpClient(), new DocumentLoader().getHttpClient());
     }
 
     @Test
-    public void differentHttpClient() throws Exception {
+    void differentHttpClient() throws Exception {
         // Custom http client
         try {
             documentLoader.setHttpClient(JsonUtils.createDefaultHttpClient());
@@ -354,13 +351,13 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void testDisallowRemoteContexts() throws Exception {
+    void disallowRemoteContexts() throws Exception {
         final String testUrl = "http://json-ld.org/contexts/person.jsonld";
         final Object test = documentLoader.loadDocument(testUrl);
 
         assertNotNull(
-                "Was not able to fetch from URL before testing disallow remote contexts loading",
-                test);
+                test,
+                "Was not able to fetch from URL before testing disallow remote contexts loading");
 
         final String disallowProperty = System
                 .getProperty(DocumentLoader.DISALLOW_REMOTE_CONTEXT_LOADING);
@@ -381,12 +378,12 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void testInjectContext() throws Exception {
+    void injectContext() throws Exception {
         injectContext(new JsonLdOptions());
     }
 
     @Test
-    public void testIssue304_remoteContextAndBaseIri() throws Exception {
+    void issue304_remoteContextAndBaseIri() throws Exception {
         injectContext(new JsonLdOptions("testing:baseIri"));
     }
 
@@ -419,7 +416,7 @@ public class DocumentLoaderTest {
     }
 
     @Test
-    public void testRemoteContextCaching() throws Exception {
+    void remoteContextCaching() throws Exception {
         final String[] urls = { "http://schema.org/", "http://schema.org/docs/jsonldcontext.json" };
         for (final String url : urls) {
             final long start = System.currentTimeMillis();

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdFramingTest.java
@@ -1,12 +1,12 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
@@ -51,7 +51,7 @@ public class JsonLdFramingTest {
         opts.setCompactArrays(false);
         opts.setProcessingMode("json-ld-1.1");
         final Map<String, Object> frame2 = JsonLdProcessor.frame(in, frame, opts);
-        assertFalse("Result should contain no blank nodes", frame2.toString().contains("_:"));
+        assertFalse(frame2.toString().contains("_:"), "Result should contain no blank nodes");
 
         final Object out = JsonUtils
                 .fromInputStream(getClass().getResourceAsStream("/custom/frame-0003-out.jsonld"));

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdPerformanceTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdPerformanceTest.java
@@ -16,31 +16,27 @@ import java.util.LongSummaryStatistics;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
-
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import com.github.jsonldjava.core.RDFDataset.Quad;
 import com.github.jsonldjava.utils.JsonUtils;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
  * @author Peter Ansell p_ansell@yahoo.com
- */
-public class JsonLdPerformanceTest {
+ */public class JsonLdPerformanceTest {
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    public File tempDir;
 
     private File testDir;
 
-    @Before
-    public void setUp() throws Exception {
-        testDir = tempDir.newFolder("jsonld-perf-tests-");
+    @BeforeEach
+    void setUp() throws Exception {
+        testDir = newFolder(tempDir, "jsonld-perf-tests-");
     }
 
     /**
@@ -50,9 +46,9 @@ public class JsonLdPerformanceTest {
      *
      * @throws Exception
      */
-    @Ignore("Enable as necessary for manual testing, particularly to test that it fails due to irregular URIs")
+    @Disabled("Enable as necessary for manual testing, particularly to test that it fails due to irregular URIs")
     @Test
-    public final void testPerformance1() throws Exception {
+    final void performance1() throws Exception {
         testCompaction("Long", new GZIPInputStream(
                 new FileInputStream(new File("/home/peter/Downloads/2000007922.jsonld.gz"))));
     }
@@ -64,9 +60,9 @@ public class JsonLdPerformanceTest {
      *
      * @throws Exception
      */
-    @Ignore("Enable as necessary to test performance")
+    @Disabled("Enable as necessary to test performance")
     @Test
-    public final void testLaxMergeValuesPerfFast() throws Exception {
+    final void laxMergeValuesPerfFast() throws Exception {
         testCompaction("Fast",
                 new FileInputStream(new File("/home/peter/Downloads/jsonldperfs/fast.jsonld")));
     }
@@ -78,9 +74,9 @@ public class JsonLdPerformanceTest {
      *
      * @throws Exception
      */
-    @Ignore("Enable as necessary to test performance")
+    @Disabled("Enable as necessary to test performance")
     @Test
-    public final void testLaxMergeValuesPerfSlow() throws Exception {
+    final void laxMergeValuesPerfSlow() throws Exception {
         testCompaction("Slow",
                 new FileInputStream(new File("/home/peter/Downloads/jsonldperfs/slow.jsonld")));
     }
@@ -113,9 +109,9 @@ public class JsonLdPerformanceTest {
         System.out.println("(" + label + ") Compact average : " + compactStats.getAverage());
     }
 
-    @Ignore("Disable performance tests by default")
+    @Disabled("Disable performance tests by default")
     @Test
-    public final void testPerformanceRandom() throws Exception {
+    final void performanceRandom() throws Exception {
         final Random prng = new Random();
         final int rounds = 10000;
 
@@ -348,9 +344,9 @@ public class JsonLdPerformanceTest {
      *
      * @author fpservant
      */
-    @Ignore("Disable performance tests by default")
+    @Disabled("Disable performance tests by default")
     @Test
-    public final void slowVsFast5Predicates() throws Exception {
+    final void slowVsFast5Predicates() throws Exception {
 
         final String ns = "http://www.example.com/foo/";
 
@@ -386,9 +382,9 @@ public class JsonLdPerformanceTest {
      *
      * @author fpservant
      */
-    @Ignore("Disable performance tests by default")
+    @Disabled("Disable performance tests by default")
     @Test
-    public final void slowVsFast2Predicates() throws Exception {
+    final void slowVsFast2Predicates() throws Exception {
 
         final String ns = "http://www.example.com/foo/";
 
@@ -424,9 +420,9 @@ public class JsonLdPerformanceTest {
      *
      * @author fpservant
      */
-    @Ignore("Disable performance tests by default")
+    @Disabled("Disable performance tests by default")
     @Test
-    public final void slowVsFast1Predicate() throws Exception {
+    final void slowVsFast1Predicate() throws Exception {
 
         final String ns = "http://www.example.com/foo/";
 
@@ -462,9 +458,9 @@ public class JsonLdPerformanceTest {
      *
      * @author fpservant
      */
-    @Ignore("Disable performance tests by default")
+    @Disabled("Disable performance tests by default")
     @Test
-    public final void slowVsFastMultipleSubjects1Predicate() throws Exception {
+    final void slowVsFastMultipleSubjects1Predicate() throws Exception {
 
         final String ns = "http://www.example.com/foo/";
 
@@ -500,9 +496,9 @@ public class JsonLdPerformanceTest {
      *
      * @author fpservant
      */
-    @Ignore("Disable performance tests by default")
+    @Disabled("Disable performance tests by default")
     @Test
-    public final void slowVsFastMultipleSubjects5Predicates() throws Exception {
+    final void slowVsFastMultipleSubjects5Predicates() throws Exception {
 
         final String ns = "http://www.example.com/foo/";
 
@@ -554,9 +550,9 @@ public class JsonLdPerformanceTest {
      *             If there is an error with the JSONLD processing.
      */
     private void runLaxVersusSlowToRDFTest(final String label, final String ns,
-            Function<Integer, String> subjectGenerator,
-            Function<Integer, String> predicateGenerator, Function<Integer, String> objectGenerator,
-            int tripleCount, int warmingRounds, int rounds) throws JsonLdError {
+                                           Function<Integer, String> subjectGenerator,
+                                           Function<Integer, String> predicateGenerator, Function<Integer, String> objectGenerator,
+                                           int tripleCount, int warmingRounds, int rounds) throws JsonLdError {
 
         System.out.println("Running test for lax versus slow for " + label);
 
@@ -607,7 +603,7 @@ public class JsonLdPerformanceTest {
      * @author fpservant
      */
     @Test
-    public final void duplicatedTriplesInAnRDFDataset() throws Exception {
+    final void duplicatedTriplesInAnRDFDataset() throws Exception {
         final RDFDataset inputRdf = new RDFDataset();
         final String ns = "http://www.example.com/foo/";
         inputRdf.setNamespace("ex", ns);
@@ -637,5 +633,14 @@ public class JsonLdPerformanceTest {
         final String jsonld2 = JsonUtils.toPrettyString(fromRDF2);
         // System.out.println(jsonld2);
 
+    }
+
+    private static File newFolder(File root, String... subDirs) throws IOException {
+        String subFolder = String.join("/", subDirs);
+        File result = new File(root, subFolder);
+        if (!result.mkdirs()) {
+            throw new IOException("Couldn't create folders " + root);
+        }
+        return result;
     }
 }

--- a/core/src/test/java/com/github/jsonldjava/core/JsonLdToRdfTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/JsonLdToRdfTest.java
@@ -1,13 +1,13 @@
 package com.github.jsonldjava.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class JsonLdToRdfTest {
+class JsonLdToRdfTest {
 
     @Test
-    public void testIssue301() throws JsonLdError {
+    void issue301() throws JsonLdError {
         final RDFDataset rdf = new RDFDataset();
         rdf.addTriple(
                 "http://www.w3.org/2002/07/owl#Class",

--- a/core/src/test/java/com/github/jsonldjava/core/LocalBaseTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/LocalBaseTest.java
@@ -1,8 +1,8 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -10,13 +10,13 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
-public class LocalBaseTest {
+class LocalBaseTest {
     @Test
-    public void testMixedLocalRemoteBaseRemoteContextFirst() throws Exception {
+    void mixedLocalRemoteBaseRemoteContextFirst() throws Exception {
 
         final Reader reader = new BufferedReader(new InputStreamReader(
                 this.getClass().getResourceAsStream("/custom/base-0001-in.jsonld"),
@@ -37,7 +37,7 @@ public class LocalBaseTest {
     }
 
     @Test
-    public void testMixedLocalRemoteBaseLocalContextFirst() throws Exception {
+    void mixedLocalRemoteBaseLocalContextFirst() throws Exception {
 
         final Reader reader = new BufferedReader(new InputStreamReader(
                 this.getClass().getResourceAsStream("/custom/base-0002-in.jsonld"),
@@ -58,7 +58,7 @@ public class LocalBaseTest {
     }
 
     @Test
-    public void testUriResolveWhenExpandingBase() throws Exception {
+    void uriResolveWhenExpandingBase() throws Exception {
 
         final Reader reader = new BufferedReader(new InputStreamReader(
                 this.getClass().getResourceAsStream("/custom/base-0003-in.jsonld"),
@@ -68,7 +68,7 @@ public class LocalBaseTest {
 
         final JsonLdOptions options = new JsonLdOptions();
         final List<Object> expanded = JsonLdProcessor.expand(input, options);
-        assertFalse("expanded form must not be empty", expanded.isEmpty());
+        assertFalse(expanded.isEmpty(), "expanded form must not be empty");
 
         final Reader outReader = new BufferedReader(new InputStreamReader(
                 this.getClass().getResourceAsStream("/custom/base-0003-out.jsonld"),

--- a/core/src/test/java/com/github/jsonldjava/core/LongestPrefixTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/LongestPrefixTest.java
@@ -1,13 +1,13 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
@@ -52,8 +52,8 @@ public class LongestPrefixTest {
         final String toJSONLD = JsonUtils.toPrettyString(fromRDF);
         // System.out.println(toJSONLD);
 
-        assertTrue("The lexicographically shortest URI was not chosen",
-                toJSONLD.contains("aat:rev/"));
+        assertTrue(toJSONLD.contains("aat:rev/"),
+                "The lexicographically shortest URI was not chosen");
     }
 
     @Test
@@ -80,8 +80,8 @@ public class LongestPrefixTest {
         final String toJSONLD = JsonUtils.toPrettyString(fromRDF);
         // System.out.println(toJSONLD);
 
-        assertFalse("The lexicographically shortest URI was not chosen",
-                toJSONLD.contains("aat:rev/"));
+        assertFalse(toJSONLD.contains("aat:rev/"),
+                "The lexicographically shortest URI was not chosen");
     }
 
     @Test
@@ -100,8 +100,8 @@ public class LongestPrefixTest {
         final String toJSONLD = JsonUtils.toPrettyString(fromRDF);
         // System.out.println(toJSONLD);
 
-        assertFalse("The lexicographically shortest URI was not chosen",
-                toJSONLD.contains("http://www.a.com/foo/p"));
+        assertFalse(toJSONLD.contains("http://www.a.com/foo/p"),
+                "The lexicographically shortest URI was not chosen");
     }
 
 }

--- a/core/src/test/java/com/github/jsonldjava/core/MinimalSchemaOrgRegressionTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/MinimalSchemaOrgRegressionTest.java
@@ -1,7 +1,7 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 
@@ -15,7 +15,7 @@ import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.cache.BasicHttpCacheStorage;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MinimalSchemaOrgRegressionTest {
 
@@ -30,7 +30,7 @@ public class MinimalSchemaOrgRegressionTest {
         // BasicHttpCacheStorage
         final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
         .setMaxObjectSize(1024 * 128).build();
-        
+
         final CloseableHttpClient httpClient = CachingHttpClientBuilder.create()
         // allow caching
         .setCacheConfig(cacheConfig)
@@ -44,7 +44,7 @@ public class MinimalSchemaOrgRegressionTest {
         .setRedirectStrategy(DefaultRedirectStrategy.INSTANCE)
         // use system defaults for proxy etc.
         .useSystemProperties().build();
-        
+
         Object content = JsonUtils.fromURL(url, httpClient);
         checkBasicConditions(content.toString());
     }
@@ -52,10 +52,10 @@ public class MinimalSchemaOrgRegressionTest {
     private void checkBasicConditions(final String outputString) {
         // Test for some basic conditions without including the JSON/JSON-LD
         // parsing code here
-        assertTrue(outputString, outputString.endsWith("}"));
-        assertFalse("Output string should not be empty: " + outputString.length(),
-                outputString.isEmpty());
-        assertTrue("Unexpected length: " + outputString.length(), outputString.length() > 100000);
+        assertTrue(outputString.endsWith("}"), outputString);
+        assertFalse(outputString.isEmpty(),
+                "Output string should not be empty: " + outputString.length());
+        assertTrue(outputString.length() > 100000, "Unexpected length: " + outputString.length());
     }
-    
+
 }

--- a/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/NodeCompareTest.java
@@ -1,7 +1,7 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.core.RDFDataset.BlankNode;
 import com.github.jsonldjava.core.RDFDataset.IRI;
@@ -68,7 +68,7 @@ public class NodeCompareTest {
         // assertEquals(expected, sorted);
         // so we'll instead do:
         for (int i = 0; i < expected.size(); i++) {
-            assertEquals("Wrong sort order at position " + i, expected.get(i), sorted.get(i));
+            assertEquals(expected.get(i), sorted.get(i), "Wrong sort order at position " + i);
         }
     }
 

--- a/core/src/test/java/com/github/jsonldjava/core/QuadCompareTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/QuadCompareTest.java
@@ -1,9 +1,9 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.core.RDFDataset.Quad;
 

--- a/core/src/test/java/com/github/jsonldjava/core/RegexTest.java
+++ b/core/src/test/java/com/github/jsonldjava/core/RegexTest.java
@@ -1,15 +1,15 @@
 package com.github.jsonldjava.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RegexTest {
     @Test

--- a/core/src/test/java/com/github/jsonldjava/utils/JarCacheTest.java
+++ b/core/src/test/java/com/github/jsonldjava/utils/JarCacheTest.java
@@ -1,9 +1,5 @@
 package com.github.jsonldjava.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -18,13 +14,15 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-public class JarCacheTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+class JarCacheTest {
 
     @Test
-    public void cacheHit() throws Exception {
+    void cacheHit() throws Exception {
         final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
                 .setMaxObjectSize(1024 * 128).build();
         final JarCacheStorage storage = new JarCacheStorage(null, cacheConfig);
@@ -37,20 +35,22 @@ public class JarCacheTest {
         assertTrue(str.contains("ex:datatype"));
     }
 
-    @Test(expected = IOException.class)
-    public void cacheMiss() throws Exception {
-        final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
-                .setMaxObjectSize(1024 * 128).build();
-        final JarCacheStorage storage = new JarCacheStorage(null, cacheConfig);
-        final HttpClient httpClient = createTestHttpClient(cacheConfig, storage);
-        final HttpGet get = new HttpGet("http://nonexisting.example.com/notfound");
-        // Should throw an IOException as the DNS name
-        // nonexisting.example.com does not exist
-        httpClient.execute(get);
+    @Test
+    void cacheMiss() throws Exception {
+        assertThrows(IOException.class, () -> {
+            final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
+                    .setMaxObjectSize(1024 * 128).build();
+            final JarCacheStorage storage = new JarCacheStorage(null, cacheConfig);
+            final HttpClient httpClient = createTestHttpClient(cacheConfig, storage);
+            final HttpGet get = new HttpGet("http://nonexisting.example.com/notfound");
+            // Should throw an IOException as the DNS name
+            // nonexisting.example.com does not exist
+            httpClient.execute(get);
+        });
     }
 
     @Test
-    public void doubleLoad() throws Exception {
+    void doubleLoad() throws Exception {
         final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
                 .setMaxObjectSize(1024 * 128).build();
         final JarCacheStorage storage = new JarCacheStorage(null, cacheConfig);
@@ -63,7 +63,7 @@ public class JarCacheTest {
     }
 
     @Test
-    public void customClassPath() throws Exception {
+    void customClassPath() throws Exception {
         final URL nestedJar = getClass().getResource("/nested.jar");
         final ClassLoader cl = new URLClassLoader(new URL[] { nestedJar });
         final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
@@ -79,7 +79,7 @@ public class JarCacheTest {
     }
 
     @Test
-    public void contextClassLoader() throws Exception {
+    void contextClassLoader() throws Exception {
         final URL nestedJar = getClass().getResource("/nested.jar");
         assertNotNull(nestedJar);
         final ClassLoader cl = new URLClassLoader(new URL[] { nestedJar });
@@ -98,13 +98,13 @@ public class JarCacheTest {
         assertEquals("{ \"Hello\": \"World!\" }", str.trim());
     }
 
-    @After
-    public void setContextClassLoader() {
+    @AfterEach
+    void setContextClassLoader() {
         Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
     }
 
     @Test
-    public void systemClassLoader() throws Exception {
+    void systemClassLoader() throws Exception {
         final URL nestedJar = getClass().getResource("/nested.jar");
         assertNotNull(nestedJar);
         final CacheConfig cacheConfig = CacheConfig.custom().setMaxCacheEntries(1000)
@@ -118,7 +118,7 @@ public class JarCacheTest {
     }
 
     private static CloseableHttpClient createTestHttpClient(CacheConfig cacheConfig,
-            JarCacheStorage jarCacheConfig) {
+                                                            JarCacheStorage jarCacheConfig) {
         final CloseableHttpClient result = CachingHttpClientBuilder.create()
                 // allow caching
                 .setCacheConfig(cacheConfig)

--- a/core/src/test/java/com/github/jsonldjava/utils/JsonUtilsTest.java
+++ b/core/src/test/java/com/github/jsonldjava/utils/JsonUtilsTest.java
@@ -1,24 +1,23 @@
 package com.github.jsonldjava.utils;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class JsonUtilsTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonUtilsTest {
     @Test
-    public void resolveTest() {
+    void resolveTest() {
         final String baseUri = "http://mysite.net";
         final String pathToResolve = "picture.jpg";
         String resolve = "";
@@ -33,7 +32,7 @@ public class JsonUtilsTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void fromStringTest() {
+    void fromStringTest() {
         final String testString = "{\"seq\":3,\"id\":\"e48dfa735d9fad88db6b7cd696002df7\",\"changes\":[{\"rev\":\"2-6aebf275bc3f29b67695c727d448df8e\"}]}";
         final String testFailure = "{{{{{{{{{{{";
         Object obj = null;
@@ -55,7 +54,7 @@ public class JsonUtilsTest {
     }
 
     @Test
-    public void testFromJsonParser() throws Exception {
+    void fromJsonParser() throws Exception {
         final ObjectMapper jsonMapper = new ObjectMapper();
         final JsonFactory jsonFactory = new JsonFactory(jsonMapper);
         final Reader testInputString = new StringReader("{}");
@@ -64,43 +63,55 @@ public class JsonUtilsTest {
     }
 
     @Test
-    public void trailingContent_1() throws JsonParseException, IOException {
+    void trailingContent_1() throws JsonParseException, IOException {
         trailingContent("{}");
     }
 
     @Test
-    public void trailingContent_2() throws JsonParseException, IOException {
+    void trailingContent_2() throws JsonParseException, IOException {
         trailingContent("{}  \t  \r \n  \r\n   ");
     }
 
-    @Test(expected = JsonParseException.class)
-    public void trailingContent_3() throws JsonParseException, IOException {
-        trailingContent("{}x");
+    @Test
+    void trailingContent_3() throws JsonParseException, IOException {
+        assertThrows(JsonParseException.class, () -> {
+            trailingContent("{}x");
+        });
     }
 
-    @Test(expected = JsonParseException.class)
-    public void trailingContent_4() throws JsonParseException, IOException {
-        trailingContent("{}   x");
+    @Test
+    void trailingContent_4() throws JsonParseException, IOException {
+        assertThrows(JsonParseException.class, () -> {
+            trailingContent("{}   x");
+        });
     }
 
-    @Test(expected = JsonParseException.class)
-    public void trailingContent_5() throws JsonParseException, IOException {
-        trailingContent("{} \"x\"");
+    @Test
+    void trailingContent_5() throws JsonParseException, IOException {
+        assertThrows(JsonParseException.class, () -> {
+            trailingContent("{} \"x\"");
+        });
     }
 
-    @Test(expected = JsonParseException.class)
-    public void trailingContent_6() throws JsonParseException, IOException {
-        trailingContent("{} {}");
+    @Test
+    void trailingContent_6() throws JsonParseException, IOException {
+        assertThrows(JsonParseException.class, () -> {
+            trailingContent("{} {}");
+        });
     }
 
-    @Test(expected = JsonParseException.class)
-    public void trailingContent_7() throws JsonParseException, IOException {
-        trailingContent("{},{}");
+    @Test
+    void trailingContent_7() throws JsonParseException, IOException {
+        assertThrows(JsonParseException.class, () -> {
+            trailingContent("{},{}");
+        });
     }
 
-    @Test(expected = JsonParseException.class)
-    public void trailingContent_8() throws JsonParseException, IOException {
-        trailingContent("{},[]");
+    @Test
+    void trailingContent_8() throws JsonParseException, IOException {
+        assertThrows(JsonParseException.class, () -> {
+            trailingContent("{},[]");
+        });
     }
 
     private void trailingContent(String string) throws JsonParseException, IOException {

--- a/core/src/test/java/com/github/jsonldjava/utils/TestUtils.java
+++ b/core/src/test/java/com/github/jsonldjava/utils/TestUtils.java
@@ -3,7 +3,7 @@
  */
 package com.github.jsonldjava.utils;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,7 +38,7 @@ public class TestUtils {
         nextFile.createNewFile();
 
         final InputStream inputStream = TestUtils.class.getResourceAsStream(resource);
-        assertNotNull("Missing test resource: " + resource, inputStream);
+        assertNotNull(inputStream, "Missing test resource: " + resource);
 
         IOUtils.copy(inputStream, new FileOutputStream(nextFile));
         return nextFile.getAbsolutePath();


### PR DESCRIPTION
Before i go with advantages, **i would like to confirm that, i did not change any test case logic.** All i did is to make it work in JUNIT 5 way of writing the same test cases.
Recently, in our automation team, we migrated our legacy applications from JUNIT 4 to JUNIT 5. We observed that there are below advantages.

**JUnit 5 Advantages**

1. Let’s start with the previous version, JUnit 4 , which has some clear limitations:
2. A single jar library contains the entire framework. We need to import the whole library, even when we only require a particular feature. In JUnit 5, we get more granularity and can import only what’s necessary.
3. Only one test runner can execute tests at a time in JUnit 4 (e.g. SpringJUnit4ClassRunner or Parameterized ). JUnit 5 allows multiple runners to work simultaneously.
4. JUnit 4 never advanced beyond Java 7, missing out on a lot of features from Java 8. JUnit 5 makes good use of the Java 8 features.
5. The idea behind JUnit 5 was to completely rewrite JUnit 4 in order to negate most of these drawbacks.

**References**
https://www.baeldung.com/junit-assert-exception
https://www.baeldung.com/parameterized-tests-junit-5
https://www.softwaretestinghelp.com/junit-ignore-test-cases/
https://www.baeldung.com/junit-5-migration